### PR TITLE
Make rabix symlink-able

### DIFF
--- a/rabix-backend-local/bin/rabix
+++ b/rabix-backend-local/bin/rabix
@@ -9,7 +9,7 @@ do
     fi
 done
 
-command="java -Dlogback.configurationFile=${loggingConfiguration} -jar $(dirname $0)/lib/rabix-backend-local.jar"
+command="java -Dlogback.configurationFile=${loggingConfiguration} -jar $(dirname "$(readlink "$0")")/lib/rabix-backend-local.jar"
 
 for i in "$@"
 do


### PR DESCRIPTION
When you link the shell script that runs the executor, it does not resolve the symlink and tries to run `/usr/bin/local/lib/rabix-backend-local.jar`.
This fixes that behaviour, so the jar file will searched for in the folder where the rabix script is located, not where its symlink is found.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rabix/bunny/50)
<!-- Reviewable:end -->
