### PR TITLE
Improved logging configurations

### DIFF
--- a/rabix-backend-local/config/logback-verbose.xml
+++ b/rabix-backend-local/config/logback-verbose.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<configuration scan="true">
+<configuration>
 	<appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+		<Target>System.err</Target>
+		<encoder>
+			<pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}] %msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<appender name="STDERR_DETAILED" class="ch.qos.logback.core.ConsoleAppender">
 		<Target>System.err</Target>
 		<encoder>
 			<pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%level] [%thread] %logger{10} [%file:%line] %msg%n</pattern>
@@ -8,7 +15,10 @@
 	</appender>
 
 	<root level="DEBUG">
-		<appender-ref ref="STDERR" />
+		<appender-ref ref="STDERR_DETAILED" />
 	</root>
+	<logger name="verbose" level="INFO" additivity="false">
+		<appender-ref ref="STDERR" />
+	</logger>
 
 </configuration>

--- a/rabix-backend-local/config/logback.xml
+++ b/rabix-backend-local/config/logback.xml
@@ -3,12 +3,15 @@
 	<appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
 		<Target>System.err</Target>
 		<encoder>
-			<pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}] %msg%n</pattern>
+			<pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%level] %msg%n</pattern>
 		</encoder>
 	</appender>
 
-	<logger name="verbose" level="INFO">
+	<root level="WARN">
 		<appender-ref ref="STDERR" />
+	</root>
+
+	<logger name="verbose" level="INFO">
 	</logger>
 
 </configuration>

--- a/rabix-common/src/main/java/org/rabix/common/logging/VerboseLogger.java
+++ b/rabix-common/src/main/java/org/rabix/common/logging/VerboseLogger.java
@@ -3,6 +3,9 @@ package org.rabix.common.logging;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * verbose logger will log all messages, regardless of -v param
+ */
 public class VerboseLogger {
 
   public static final String LOGGER_NAME = "verbose";

--- a/rabix-tes-command-line/config/logback-verbose.xml
+++ b/rabix-tes-command-line/config/logback-verbose.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<configuration scan="true">
+<configuration>
 	<appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+		<Target>System.err</Target>
+		<encoder>
+			<pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}] %msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<appender name="STDERR_DETAILED" class="ch.qos.logback.core.ConsoleAppender">
 		<Target>System.err</Target>
 		<encoder>
 			<pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%level] [%thread] %logger{10} [%file:%line] %msg%n</pattern>
@@ -8,7 +15,10 @@
 	</appender>
 
 	<root level="DEBUG">
-		<appender-ref ref="STDERR" />
+		<appender-ref ref="STDERR_DETAILED" />
 	</root>
+	<logger name="verbose" level="INFO" additivity="false">
+		<appender-ref ref="STDERR" />
+	</logger>
 
 </configuration>

--- a/rabix-tes-command-line/config/logback.xml
+++ b/rabix-tes-command-line/config/logback.xml
@@ -3,12 +3,15 @@
 	<appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
 		<Target>System.err</Target>
 		<encoder>
-			<pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}] %msg%n</pattern>
+			<pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%level] %msg%n</pattern>
 		</encoder>
 	</appender>
 
-	<logger name="verbose" level="INFO">
+	<root level="WARN">
 		<appender-ref ref="STDERR" />
+	</root>
+
+	<logger name="verbose" level="INFO">
 	</logger>
 
 </configuration>


### PR DESCRIPTION
VerboseLogger now logs everything, regardless of -v param
Every other logger has a default level of WARN. Specifying -v option will change it to DEBUG, and add some more details in the log line (Line in the code where error occurred, etc.)