### PR TITLE
Fix for ports with the same name issue #117

### DIFF
--- a/rabix-engine/src/main/java/org/rabix/engine/processor/handler/impl/OutputEventHandler.java
+++ b/rabix-engine/src/main/java/org/rabix/engine/processor/handler/impl/OutputEventHandler.java
@@ -203,7 +203,7 @@ public class OutputEventHandler implements EventHandler<OutputUpdateEvent> {
               int position = InternalSchemaHelper.getScatteredNumber(sourceJob.getId());
               Event updateOutputEvent = new OutputUpdateEvent(event.getContextId(), destinationVariable.getJobId(), destinationVariable.getPortId(), value, true, numberOfScattered, position, event.getEventGroupId());
               eventProcessor.send(updateOutputEvent);
-            } else {
+            } else if(InternalSchemaHelper.getParentId(sourceJob.getId()).equals(destinationVariable.getJobId())) {
               Event updateOutputEvent = new OutputUpdateEvent(event.getContextId(), destinationVariable.getJobId(), destinationVariable.getPortId(), value, link.getPosition(), event.getEventGroupId());
               eventProcessor.send(updateOutputEvent);
             }


### PR DESCRIPTION
Prevents the accidental triggering of an output update event on a sepp by a previous step.

Relates to the case when a step’s input port and output port have the same name, described in: https://github.com/rabix/bunny/issues/117