### PR TITLE
Wider string sanitization for folder naming

### DIFF
--- a/rabix-executor/src/main/java/org/rabix/executor/config/impl/DefaultStorageConfiguration.java
+++ b/rabix-executor/src/main/java/org/rabix/executor/config/impl/DefaultStorageConfiguration.java
@@ -84,11 +84,7 @@ public class DefaultStorageConfiguration implements StorageConfiguration {
    * Normalize application ID
    */
   private static String sanitize(String id) {
-    id = id.replace("@", "_");
-    id = id.replace("/", "_");
-    id = id.replace("^", "_");
-    id = id.replace(":", "_");
-    return id.replaceAll("_+", "_");
+    return id.replaceAll("[^A-Za-z0-9 ]", "_");
   }
 
 }


### PR DESCRIPTION
Replaces all non-alphanumeric characters in step ids with '_'

Relates to errors that happen when a folder to be created contains > < or similar chars
https://github.com/rabix/bunny/issues/149