### PR TITLE
Engine status callback change

### DIFF
--- a/rabix-engine-rest/src/main/java/org/rabix/engine/rest/ServerBuilder.java
+++ b/rabix-engine-rest/src/main/java/org/rabix/engine/rest/ServerBuilder.java
@@ -38,11 +38,11 @@ import org.rabix.engine.service.SchedulerService;
 import org.rabix.engine.service.SchedulerService.SchedulerCallback;
 import org.rabix.engine.service.impl.BackendServiceImpl;
 import org.rabix.engine.service.impl.BootstrapServiceImpl;
-import org.rabix.engine.service.impl.EngineStatusCallbackImpl;
 import org.rabix.engine.service.impl.JobServiceImpl;
 import org.rabix.engine.service.impl.NoOpIntermediaryFilesServiceImpl;
 import org.rabix.engine.service.impl.SchedulerServiceImpl;
 import org.rabix.engine.status.EngineStatusCallback;
+import org.rabix.engine.status.impl.NoOpEngineStatusCallback;
 import org.rabix.engine.stub.BackendStubFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,7 +74,7 @@ public class ServerBuilder {
           @Override
           protected void configure() {
             bind(JobService.class).to(JobServiceImpl.class).in(Scopes.SINGLETON);
-            bind(EngineStatusCallback.class).to(EngineStatusCallbackImpl.class).in(Scopes.SINGLETON);
+            bind(EngineStatusCallback.class).to(NoOpEngineStatusCallback.class).in(Scopes.SINGLETON);
             bind(SchedulerCallback.class).to(SchedulerServiceImpl.class).in(Scopes.SINGLETON);
             bind(BootstrapService.class).to(BootstrapServiceImpl.class).in(Scopes.SINGLETON);
             bind(BackendService.class).to(BackendServiceImpl.class).in(Scopes.SINGLETON);

--- a/rabix-engine/src/main/java/org/rabix/engine/processor/EventProcessor.java
+++ b/rabix-engine/src/main/java/org/rabix/engine/processor/EventProcessor.java
@@ -8,7 +8,7 @@ import org.rabix.engine.status.EngineStatusCallback;
 
 public interface EventProcessor {
 
-  void start(EngineStatusCallback engineStatusCallback);
+  void start();
 
   void stop();
 

--- a/rabix-engine/src/main/java/org/rabix/engine/processor/handler/HandlerFactory.java
+++ b/rabix-engine/src/main/java/org/rabix/engine/processor/handler/HandlerFactory.java
@@ -28,14 +28,6 @@ public class HandlerFactory {
     this.contextStatusEventHandler = contextStatusEventHandler;
   }
   
-  /**
-   * Initialize some callbacks 
-   */
-  public void initialize(EngineStatusCallback engineStatusCallback) {
-    this.statusEventHandler.initialize(engineStatusCallback);
-    this.outputEventHandler.initialize(engineStatusCallback);
-  }
-  
   @SuppressWarnings("unchecked")
   public <T extends Event> EventHandler<T> get(EventType eventType) {
     switch (eventType) {

--- a/rabix-engine/src/main/java/org/rabix/engine/processor/handler/impl/JobStatusEventHandler.java
+++ b/rabix-engine/src/main/java/org/rabix/engine/processor/handler/impl/JobStatusEventHandler.java
@@ -33,12 +33,13 @@ import org.rabix.engine.processor.EventProcessor;
 import org.rabix.engine.processor.handler.EventHandler;
 import org.rabix.engine.processor.handler.EventHandlerException;
 import org.rabix.engine.repository.JobRepository;
+import org.rabix.engine.service.JobService;
 import org.rabix.engine.service.impl.CacheService;
 import org.rabix.engine.service.impl.ContextRecordService;
 import org.rabix.engine.service.impl.JobRecordService;
+import org.rabix.engine.service.impl.JobRecordService.JobState;
 import org.rabix.engine.service.impl.LinkRecordService;
 import org.rabix.engine.service.impl.VariableRecordService;
-import org.rabix.engine.service.impl.JobRecordService.JobState;
 import org.rabix.engine.status.EngineStatusCallback;
 import org.rabix.engine.validator.JobStateValidationException;
 import org.rabix.engine.validator.JobStateValidator;
@@ -62,16 +63,14 @@ public class JobStatusEventHandler implements EventHandler<JobStatusEvent> {
   private final ContextRecordService contextRecordService;
   
   private final JobRepository jobRepository;
-  
-  private EngineStatusCallback engineStatusCallback;
-  
+  private final JobService jobService;
   private final CacheService cacheService;
 
   @Inject
   public JobStatusEventHandler(final DAGNodeDB dagNodeDB, final AppDB appDB, final JobRecordService jobRecordService,
       final LinkRecordService linkRecordService, final VariableRecordService variableRecordService,
       final ContextRecordService contextRecordService, final EventProcessor eventProcessor,
-      final ScatterHandler scatterHelper, final JobRepository jobRepository, final CacheService cacheService) {
+      final ScatterHandler scatterHelper, final JobRepository jobRepository, final CacheService cacheService, final JobService jobService) {
     this.dagNodeDB = dagNodeDB;
     this.scatterHelper = scatterHelper;
     this.eventProcessor = eventProcessor;
@@ -80,13 +79,10 @@ public class JobStatusEventHandler implements EventHandler<JobStatusEvent> {
     this.contextRecordService = contextRecordService;
     this.variableRecordService = variableRecordService;
     this.appDB = appDB;
+    this.jobService = jobService;
     
     this.cacheService = cacheService;
     this.jobRepository = jobRepository;
-  }
-
-  public void initialize(EngineStatusCallback engineStatusCallback) {
-    this.engineStatusCallback = engineStatusCallback;
   }
 
   @Override
@@ -123,21 +119,18 @@ public class JobStatusEventHandler implements EventHandler<JobStatusEvent> {
           logger.info("Failed to create job", e1);
         }
       }
-      else {
-        Job containerJob = null;
-        try {
-          containerJob = JobHelper.createJob(jobRecord, JobStatus.READY, jobRecordService, variableRecordService, linkRecordService, contextRecordService, dagNodeDB, appDB, false);
-        } catch (BindingException e) {
-          logger.error("Failed to create containerJob " + containerJob, e);
-          throw new EventHandlerException("Failed to call onReady callback for Job " + containerJob, e);
+        else {
+          Job containerJob = null;
+          try {
+            containerJob = JobHelper.createJob(jobRecord, JobStatus.READY, jobRecordService, variableRecordService, linkRecordService, contextRecordService,
+                dagNodeDB, appDB, false);
+          } catch (BindingException e) {
+            logger.error("Failed to create containerJob " + containerJob, e);
+            throw new EventHandlerException("Failed to call onReady callback for Job " + containerJob, e);
+          }
+          jobService.handleJobContainerReady(containerJob);
+
         }
-        try {
-          engineStatusCallback.onJobContainerReady(containerJob);
-        } catch (Exception e) {
-          logger.error("Failed to call onReady callback for Job " + containerJob, e);
-          throw new EventHandlerException("Failed to call onReady callback for Job " + containerJob, e);
-        }
-      }
       break;
     case RUNNING:
       jobRecord.setState(JobState.RUNNING);
@@ -158,7 +151,7 @@ public class JobStatusEventHandler implements EventHandler<JobStatusEvent> {
           }
           eventProcessor.send(new ContextStatusEvent(event.getContextId(), ContextStatus.COMPLETED));
           Job rootJob = JobHelper.createRootJob(jobRecord, JobStatus.COMPLETED, jobRecordService, variableRecordService, linkRecordService, contextRecordService, dagNodeDB, appDB, event.getResult());
-          engineStatusCallback.onJobRootCompleted(rootJob);
+          jobService.handleJobRootCompleted(rootJob);
           deleteRecords(rootJob.getId());
           cacheService.remove(jobRecord.getRootId());
         } catch (Exception e) {
@@ -179,7 +172,7 @@ public class JobStatusEventHandler implements EventHandler<JobStatusEvent> {
       if (jobRecord.isRoot()) {
         try {
           Job rootJob = JobHelper.createRootJob(jobRecord, JobStatus.FAILED, jobRecordService, variableRecordService, linkRecordService, contextRecordService, dagNodeDB, appDB, null);
-          engineStatusCallback.onJobRootFailed(rootJob);
+          jobService.handleJobRootFailed(rootJob);
           
           eventProcessor.send(new ContextStatusEvent(event.getContextId(), ContextStatus.FAILED));
           cacheService.remove(jobRecord.getRootId());
@@ -190,7 +183,7 @@ public class JobStatusEventHandler implements EventHandler<JobStatusEvent> {
       } else {
         try {
           Job failedJob = JobHelper.createCompletedJob(jobRecord, JobStatus.FAILED, jobRecordService, variableRecordService, linkRecordService, contextRecordService, dagNodeDB, appDB);
-          engineStatusCallback.onJobFailed(failedJob);
+          jobService.handleJobFailed(failedJob);
           
           eventProcessor.send(new JobStatusEvent(InternalSchemaHelper.ROOT_NAME, event.getContextId(), JobState.FAILED, null, event.getEventGroupId(), event.getProducedByNode()));
         } catch (Exception e) {

--- a/rabix-engine/src/main/java/org/rabix/engine/processor/handler/impl/OutputEventHandler.java
+++ b/rabix-engine/src/main/java/org/rabix/engine/processor/handler/impl/OutputEventHandler.java
@@ -24,11 +24,12 @@ import org.rabix.engine.model.scatter.ScatterStrategy;
 import org.rabix.engine.processor.EventProcessor;
 import org.rabix.engine.processor.handler.EventHandler;
 import org.rabix.engine.processor.handler.EventHandlerException;
+import org.rabix.engine.service.JobService;
 import org.rabix.engine.service.impl.ContextRecordService;
 import org.rabix.engine.service.impl.JobRecordService;
+import org.rabix.engine.service.impl.JobRecordService.JobState;
 import org.rabix.engine.service.impl.LinkRecordService;
 import org.rabix.engine.service.impl.VariableRecordService;
-import org.rabix.engine.service.impl.JobRecordService.JobState;
 import org.rabix.engine.status.EngineStatusCallback;
 import org.rabix.engine.status.EngineStatusCallbackException;
 import org.slf4j.Logger;
@@ -43,7 +44,7 @@ public class OutputEventHandler implements EventHandler<OutputUpdateEvent> {
 
   private final static Logger logger = LoggerFactory.getLogger(OutputEventHandler.class);
   
-  private JobRecordService jobService;
+  private JobRecordService jobRecordService;
   private LinkRecordService linkService;
   private VariableRecordService variableService;
   private ContextRecordService contextService;
@@ -52,42 +53,37 @@ public class OutputEventHandler implements EventHandler<OutputUpdateEvent> {
   
   private DAGNodeDB dagNodeDB;
   private AppDB appDB;
-  private EngineStatusCallback engineStatusCallback;
+  private JobService jobService;
   
   @Inject
-  public OutputEventHandler(EventProcessor eventProcessor, JobRecordService jobService, VariableRecordService variableService, LinkRecordService linkService, ContextRecordService contextService, DAGNodeDB dagNodeDB, AppDB appDB) {
+  public OutputEventHandler(EventProcessor eventProcessor, JobRecordService jobRecordService, VariableRecordService variableService, LinkRecordService linkService, ContextRecordService contextService, DAGNodeDB dagNodeDB, AppDB appDB, JobService jobService) {
     this.dagNodeDB = dagNodeDB;
     this.appDB = appDB;
-    this.jobService = jobService;
+    this.jobRecordService = jobRecordService;
     this.linkService = linkService;
     this.contextService = contextService;
     this.variableService = variableService;
     this.eventProcessor = eventProcessor;
-  }
-
-  public void initialize(EngineStatusCallback engineStatusCallback) {
-    this.engineStatusCallback = engineStatusCallback;
+    this.jobService = jobService;
   }
   
   public void handle(final OutputUpdateEvent event) throws EventHandlerException {
-    JobRecord sourceJob = jobService.find(event.getJobId(), event.getContextId());
+    JobRecord sourceJob = jobRecordService.find(event.getJobId(), event.getContextId());
     if (event.isFromScatter()) {
-      jobService.resetOutputPortCounter(sourceJob, event.getNumberOfScattered(), event.getPortId());
+      jobRecordService.resetOutputPortCounter(sourceJob, event.getNumberOfScattered(), event.getPortId());
     }
     VariableRecord sourceVariable = variableService.find(event.getJobId(), event.getPortId(), LinkPortType.OUTPUT, event.getContextId());
-    jobService.decrementPortCounter(sourceJob, event.getPortId(), LinkPortType.OUTPUT);
+    jobRecordService.decrementPortCounter(sourceJob, event.getPortId(), LinkPortType.OUTPUT);
     variableService.addValue(sourceVariable, event.getValue(), event.getPosition(), sourceJob.isScatterWrapper() || event.isFromScatter());
     variableService.update(sourceVariable); // TODO wha?
-    jobService.update(sourceJob);
+    jobRecordService.update(sourceJob);
     
     if (sourceJob.isCompleted()) {
       try {
-        Job completedJob = JobHelper.createCompletedJob(sourceJob, JobStatus.COMPLETED, jobService, variableService, linkService, contextService, dagNodeDB, appDB);
-        engineStatusCallback.onJobCompleted(completedJob);
+        Job completedJob = JobHelper.createCompletedJob(sourceJob, JobStatus.COMPLETED, jobRecordService, variableService, linkService, contextService, dagNodeDB, appDB);
+        jobService.handleJobCompleted(completedJob);
       } catch (BindingException e) {
         logger.error("Failed to create Job " + sourceJob.getId(), e);
-      } catch (EngineStatusCallbackException e) {
-        logger.error("Failed to call onJobCompleted callback for Job " + sourceJob.getId(), e);
       }
       
       if (sourceJob.isRoot()) {
@@ -106,12 +102,7 @@ public class OutputEventHandler implements EventHandler<OutputUpdateEvent> {
     }
     
     if (sourceJob.isRoot()) {
-      try {
-        engineStatusCallback.onJobRootPartiallyCompleted(createRootJob(sourceJob, JobHelper.transformStatus(sourceJob.getState())));
-      } catch (EngineStatusCallbackException e) {
-        logger.error("Failed to call onReady callback for Job " + sourceJob.getId(), e);
-        throw new EventHandlerException("Failed to call onJobRootPartiallyCompleted callback for Job " + sourceJob.getId(), e);
-      }
+        jobService.handleJobRootPartiallyCompleted(createRootJob(sourceJob, JobHelper.transformStatus(sourceJob.getState())));
     }
     
     Object value = null;
@@ -141,7 +132,7 @@ public class OutputEventHandler implements EventHandler<OutputUpdateEvent> {
         for (VariableRecord destinationVariable : destinationVariables) {
           switch (destinationVariable.getType()) {
           case INPUT:
-            destinationJob = jobService.find(destinationVariable.getJobId(), destinationVariable.getRootId());
+            destinationJob = jobRecordService.find(destinationVariable.getJobId(), destinationVariable.getRootId());
             isDestinationPortScatterable = destinationJob.isScatterPort(destinationVariable.getPortId());
             if (isDestinationPortScatterable && !destinationJob.isBlocking() && !(destinationJob.getInputPortIncoming(event.getPortId()) > 1)) {
               value = value != null ? value : event.getValue();
@@ -157,7 +148,7 @@ public class OutputEventHandler implements EventHandler<OutputUpdateEvent> {
             }
             break;
           case OUTPUT:
-            destinationJob = jobService.find(destinationVariable.getJobId(), destinationVariable.getRootId());
+            destinationJob = jobRecordService.find(destinationVariable.getJobId(), destinationVariable.getRootId());
             if (destinationJob.getOutputPortIncoming(event.getPortId()) > 1) {
               if (sourceJob.isOutputPortReady(event.getPortId())) {
                 value = value != null? value : variableService.getValue(sourceVariable);
@@ -218,7 +209,7 @@ public class OutputEventHandler implements EventHandler<OutputUpdateEvent> {
       Object value = CloneHelper.deepCopy(variableService.getValue(outputVariable));
       outputs.put(outputVariable.getPortId(), value);
     }
-    return JobHelper.createRootJob(jobRecord, status, jobService, variableService, linkService, contextService, dagNodeDB, appDB, outputs);
+    return JobHelper.createRootJob(jobRecord, status, jobRecordService, variableService, linkService, contextService, dagNodeDB, appDB, outputs);
   }
   
 }

--- a/rabix-engine/src/main/java/org/rabix/engine/processor/impl/EventProcessorImpl.java
+++ b/rabix-engine/src/main/java/org/rabix/engine/processor/impl/EventProcessorImpl.java
@@ -23,9 +23,9 @@ import org.rabix.engine.repository.EventRepository;
 import org.rabix.engine.repository.JobRepository;
 import org.rabix.engine.repository.TransactionHelper;
 import org.rabix.engine.repository.TransactionHelper.TransactionException;
+import org.rabix.engine.service.JobService;
 import org.rabix.engine.service.impl.CacheService;
 import org.rabix.engine.service.impl.ContextRecordService;
-import org.rabix.engine.status.EngineStatusCallback;
 import org.rabix.engine.status.EngineStatusCallbackException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,22 +58,22 @@ public class EventProcessorImpl implements EventProcessor {
   
   private final JobRepository jobRepository;
   private final EventRepository eventRepository;
+  private final JobService jobService;
   
   @Inject
   public EventProcessorImpl(HandlerFactory handlerFactory, ContextRecordService contextRecordService,
       TransactionHelper transactionHelper, CacheService cacheService, EventRepository eventRepository,
-      JobRepository jobRepository) {
+      JobRepository jobRepository, JobService jobService) {
     this.handlerFactory = handlerFactory;
     this.contextRecordService = contextRecordService;
     this.transactionHelper = transactionHelper;
     this.cacheService = cacheService;
     this.eventRepository = eventRepository;
     this.jobRepository = jobRepository;
+    this.jobService = jobService;
   }
 
-  public void start(EngineStatusCallback engineStatusCallback) {
-    this.handlerFactory.initialize(engineStatusCallback);
-    
+  public void start() {
     executorService.execute(new Runnable() {
       @Override
       public void run() {
@@ -94,12 +94,8 @@ public class EventProcessorImpl implements EventProcessor {
                 cacheService.flush(eventReference.get().getContextId());
                 
                 Set<Job> readyJobs = jobRepository.getReadyJobsByGroupId(eventReference.get().getEventGroupId());
-                try {
-                  engineStatusCallback.onJobsReady(readyJobs);
-                } catch (EngineStatusCallbackException e) {
-                  logger.error("Failed to call onJobsReady() callback", e);
-                  // TODO handle exception
-                }
+                jobService.handleJobsReady(readyJobs);
+ 
 //                eventRepository.update(eventReference.get().getEventGroupId(), eventReference.get().getPersistentType(), Event.EventStatus.PROCESSED);
                 eventRepository.delete(eventReference.get().getEventGroupId());
                 return null;

--- a/rabix-engine/src/main/java/org/rabix/engine/processor/impl/MultiEventProcessorImpl.java
+++ b/rabix-engine/src/main/java/org/rabix/engine/processor/impl/MultiEventProcessorImpl.java
@@ -35,9 +35,9 @@ public class MultiEventProcessorImpl implements EventProcessor {
   }
 
   @Override
-  public void start(EngineStatusCallback engineStatusCallback) {
+  public void start() {
     for (EventProcessorImpl singleEventProcessor : eventProcessors.values()) {
-      singleEventProcessor.start(engineStatusCallback);
+      singleEventProcessor.start();
     }
     this.isRunning = true;
   }

--- a/rabix-engine/src/main/java/org/rabix/engine/service/JobService.java
+++ b/rabix-engine/src/main/java/org/rabix/engine/service/JobService.java
@@ -34,4 +34,20 @@ public interface JobService {
 
   Job get(UUID id);
 
+  void handleJobCompleted(Job job);
+
+  void handleJobRootPartiallyCompleted(Job rootJob);
+
+  void handleJobRootFailed(Job job);
+
+  void handleJobRootCompleted(Job job);
+
+  void handleJobFailed(Job failedJob);
+
+  void handleJobsReady(Set<Job> jobs);
+
+  void handleJobReady(Job job);
+
+  void handleJobContainerReady(Job containerJob);
+
 }

--- a/rabix-engine/src/main/java/org/rabix/engine/service/impl/JobServiceImpl.java
+++ b/rabix-engine/src/main/java/org/rabix/engine/service/impl/JobServiceImpl.java
@@ -1,16 +1,23 @@
 package org.rabix.engine.service.impl;
 
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.apache.commons.configuration.Configuration;
 import org.rabix.bindings.Bindings;
 import org.rabix.bindings.BindingsFactory;
 import org.rabix.bindings.model.Job;
 import org.rabix.bindings.model.Job.JobStatus;
+import org.rabix.bindings.model.Resources;
 import org.rabix.bindings.model.dag.DAGNode;
+import org.rabix.common.SystemEnvironmentHelper;
 import org.rabix.common.helper.InternalSchemaHelper;
 import org.rabix.engine.JobHelper;
 import org.rabix.engine.db.AppDB;
@@ -18,16 +25,19 @@ import org.rabix.engine.db.DAGNodeDB;
 import org.rabix.engine.event.Event;
 import org.rabix.engine.event.impl.InitEvent;
 import org.rabix.engine.event.impl.JobStatusEvent;
+import org.rabix.engine.helper.IntermediaryFilesHelper;
 import org.rabix.engine.model.JobRecord;
 import org.rabix.engine.processor.EventProcessor;
 import org.rabix.engine.repository.JobRepository;
 import org.rabix.engine.repository.JobRepository.JobEntity;
 import org.rabix.engine.repository.TransactionHelper;
+import org.rabix.engine.service.IntermediaryFilesService;
 import org.rabix.engine.service.JobService;
 import org.rabix.engine.service.JobServiceException;
 import org.rabix.engine.service.SchedulerService;
 import org.rabix.engine.service.impl.JobRecordService.JobState;
 import org.rabix.engine.status.EngineStatusCallback;
+import org.rabix.engine.status.EngineStatusCallbackException;
 import org.rabix.engine.validator.JobStateValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,9 +61,24 @@ public class JobServiceImpl implements JobService {
   private final SchedulerService scheduler;
   
   private final TransactionHelper transactionHelper;
+
+  private boolean deleteFilesUponExecution;
+  private boolean deleteIntermediaryFiles;
+  private boolean keepInputFiles;
+  private boolean isLocalBackend;
+
+  private IntermediaryFilesService intermediaryFilesService;
+  private static final long FREE_RESOURCES_WAIT_TIME = 3000L;
+
+  private final ExecutorService executorService = Executors.newSingleThreadExecutor();
+  private Set<UUID> stoppingRootIds = new HashSet<>();
+  private EngineStatusCallback engineStatusCallback;
   
   @Inject
-  public JobServiceImpl(EventProcessor eventProcessor, JobRecordService jobRecordService, VariableRecordService variableRecordService, LinkRecordService linkRecordService, ContextRecordService contextRecordService, SchedulerService scheduler, DAGNodeDB dagNodeDB, AppDB appDB, JobRepository jobRepository, TransactionHelper transactionHelper, EngineStatusCallback statusCallback) {
+  public JobServiceImpl(EventProcessor eventProcessor, JobRecordService jobRecordService, VariableRecordService variableRecordService,
+      LinkRecordService linkRecordService, ContextRecordService contextRecordService, SchedulerService scheduler, DAGNodeDB dagNodeDB, AppDB appDB,
+      JobRepository jobRepository, TransactionHelper transactionHelper, EngineStatusCallback statusCallback, Configuration configuration, IntermediaryFilesService intermediaryFilesService) {
+    
     this.dagNodeDB = dagNodeDB;
     this.appDB = appDB;
     this.eventProcessor = eventProcessor;
@@ -65,8 +90,13 @@ public class JobServiceImpl implements JobService {
     this.contextRecordService = contextRecordService;
     this.scheduler = scheduler;
     this.transactionHelper = transactionHelper;
+    this.engineStatusCallback = statusCallback;
+    this.intermediaryFilesService = intermediaryFilesService;
     
-    this.eventProcessor.start(statusCallback);
+    deleteFilesUponExecution = configuration.getBoolean("rabix.delete_files_upon_execution", false);
+    deleteIntermediaryFiles = configuration.getBoolean("rabix.delete_intermediary_files", false);
+    keepInputFiles = configuration.getBoolean("rabix.keep_input_files", true);
+    isLocalBackend = configuration.getBoolean("local.backend", false);
   }
   
   @Override
@@ -231,4 +261,179 @@ public class JobServiceImpl implements JobService {
     return jobRepository.getReadyFree();
   }
 
+  @Override
+  public void handleJobReady(Job job) {
+    if (isLocalBackend) {
+      long numberOfCores;
+      long memory;
+      if (job.getConfig() != null) {
+        numberOfCores = job.getConfig().get("allocatedResources.cpu") != null ? Long.parseLong((String) job.getConfig().get("allocatedResources.cpu")) : SystemEnvironmentHelper.getNumberOfCores();
+        memory = job.getConfig().get("allocatedResources.mem") != null ? Long.parseLong((String) job.getConfig().get("allocatedResources.mem")) : SystemEnvironmentHelper.getTotalPhysicalMemorySizeInMB();
+      } else {
+        numberOfCores = SystemEnvironmentHelper.getNumberOfCores();
+        memory = SystemEnvironmentHelper.getTotalPhysicalMemorySizeInMB();
+      }
+      Resources resources = new Resources(numberOfCores, memory, null, true, null, null, null, null);
+      job = Job.cloneWithResources(job, resources);
+      jobRepository.update(job);
+    }
+    try {
+      engineStatusCallback.onJobReady(job);
+    } catch (EngineStatusCallbackException e) {
+      logger.error("Engine status callback failed",e);
+    }
+  }
+
+  @Override
+  public void handleJobsReady(Set<Job> jobs){
+    for (Job job : jobs) {
+      handleJobReady(job);
+    }
+  }
+
+
+  @Override
+  public void handleJobFailed(final Job failedJob){
+    if (isLocalBackend) {
+      synchronized (stoppingRootIds) {
+        if (stoppingRootIds.contains(failedJob.getRootId())) {
+          return;
+        }
+        stoppingRootIds.add(failedJob.getRootId());
+
+        try {
+          stop(failedJob.getRootId());
+        } catch (JobServiceException e) {
+          logger.error("Failed to stop Root job " + failedJob.getRootId(), e);
+        }
+        executorService.submit(new Runnable() {
+          @Override
+          public void run() {
+            while (true) {
+              try {
+                boolean exit = true;
+                for (Job job : jobRepository.getByRootId(failedJob.getRootId())) {
+                  if (!job.isRoot() && !isFinished(job.getStatus())) {
+                    exit = false;
+                    break;
+                  }
+                }
+                if (exit) {
+                  handleJobRootFailed(failedJob);
+                  break;
+                }
+                Thread.sleep(TimeUnit.SECONDS.toMillis(2));
+              } catch (Exception e) {
+                logger.error("Failed to stop root Job " + failedJob.getRootId(), e);
+                break;
+              }
+            }
+          }
+        });
+      }
+    }
+    if (deleteIntermediaryFiles) {
+      IntermediaryFilesHelper.handleJobFailed(failedJob, jobRepository.get(failedJob.getRootId()), intermediaryFilesService, keepInputFiles);
+    }
+    try {
+      engineStatusCallback.onJobFailed(failedJob);
+    } catch (EngineStatusCallbackException e) {
+      logger.error("Engine status callback failed", e);
+    }
+  }
+
+  private boolean isFinished(JobStatus jobStatus) {
+    switch (jobStatus) {
+      case COMPLETED:
+      case FAILED:
+      case ABORTED:
+        return true;
+      default:
+        return false;
+    }
+  }
+  @Override
+  public void handleJobContainerReady(Job containerJob) {
+    if (deleteIntermediaryFiles) {
+      IntermediaryFilesHelper.handleContainerReady(containerJob, linkRecordService, intermediaryFilesService, keepInputFiles);
+    }
+    try {
+      engineStatusCallback.onJobContainerReady(containerJob);
+    } catch (EngineStatusCallbackException e) {
+      logger.error("Engine status callback failed", e);
+    }
+  }
+
+  @Override
+  public void handleJobRootCompleted(Job job){
+    if (deleteFilesUponExecution) {
+      scheduler.freeBackend(job);
+
+      if (isLocalBackend) {
+        try {
+          Thread.sleep(FREE_RESOURCES_WAIT_TIME);
+        } catch (InterruptedException e) {
+        }
+      }
+    }
+
+    job = Job.cloneWithStatus(job, JobStatus.COMPLETED);
+    job = JobHelper.fillOutputs(job, jobRecordService, variableRecordService);
+    jobRepository.update(job);
+    try {
+      engineStatusCallback.onJobRootCompleted(job);
+    } catch (EngineStatusCallbackException e) {
+      logger.error("Engine status callback failed", e);
+    }
+  }
+
+  @Override
+  public void handleJobRootFailed(Job job){
+    synchronized (stoppingRootIds) {
+      if (deleteFilesUponExecution) {
+        scheduler.freeBackend(job);
+
+        if (isLocalBackend) {
+          try {
+            Thread.sleep(FREE_RESOURCES_WAIT_TIME);
+          } catch (InterruptedException e) {
+          }
+        }
+      }
+
+      job = Job.cloneWithStatus(job, JobStatus.FAILED);
+      jobRepository.update(job);
+
+      scheduler.deallocate(job);
+      stoppingRootIds.remove(job.getId());
+    }
+    try {
+      engineStatusCallback.onJobRootFailed(job);
+    } catch (EngineStatusCallbackException e) {
+      logger.error("Engine status callback failed", e);
+    }
+  }
+
+  @Override
+  public void handleJobRootPartiallyCompleted(Job rootJob){
+    logger.info("Root {} is partially completed.", rootJob.getId());
+    try{
+      engineStatusCallback.onJobRootPartiallyCompleted(rootJob);
+    } catch (EngineStatusCallbackException e) {
+      logger.error("Engine status callback failed",e);
+    }
+  }
+
+  @Override
+  public void handleJobCompleted(Job job){
+    logger.info("Job {} is completed.", job.getName());
+    if (deleteIntermediaryFiles) {
+      IntermediaryFilesHelper.handleJobCompleted(job, linkRecordService, intermediaryFilesService);
+    }
+    try{
+      engineStatusCallback.onJobCompleted(job);
+    } catch (EngineStatusCallbackException e) {
+      logger.error("Engine status callback failed",e);
+    }
+  }
 }

--- a/rabix-engine/src/main/java/org/rabix/engine/service/impl/JobServiceImpl.java
+++ b/rabix-engine/src/main/java/org/rabix/engine/service/impl/JobServiceImpl.java
@@ -97,6 +97,7 @@ public class JobServiceImpl implements JobService {
     deleteIntermediaryFiles = configuration.getBoolean("rabix.delete_intermediary_files", false);
     keepInputFiles = configuration.getBoolean("rabix.keep_input_files", true);
     isLocalBackend = configuration.getBoolean("local.backend", false);
+    eventProcessor.start();
   }
   
   @Override

--- a/rabix-engine/src/test/java/org/rabix/engine/EngineModuleTest.java
+++ b/rabix-engine/src/test/java/org/rabix/engine/EngineModuleTest.java
@@ -33,7 +33,6 @@ import org.rabix.engine.service.impl.JobRecordService;
 import org.rabix.engine.service.impl.LinkRecordService;
 import org.rabix.engine.service.impl.VariableRecordService;
 import org.rabix.engine.status.EngineStatusCallback;
-import org.rabix.engine.status.impl.NoOpEngineStatusCallback;
 import org.rabix.engine.test.DummyConfigModule;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -74,7 +73,7 @@ public class EngineModuleTest {
   public void testNull() throws Exception {
     EngineStatusCallback esc = mock(EngineStatusCallback.class);
 
-    ep.start(esc);
+    ep.start();
     String simpleApp = ResourceHelper.readResource("apps/null.cwl.yml");
     String appUrl = URIHelper.createDataURI(simpleApp);
     Bindings b = BindingsFactory.create(appUrl);
@@ -129,7 +128,7 @@ public class EngineModuleTest {
 
   @Test(enabled=false)
   public void testSimple() throws Exception {
-    ep.start(new NoOpEngineStatusCallback());
+    ep.start();
 
     String simpleApp = ResourceHelper.readResource("apps/simple.cwl.yml");
     String appUrl = URIHelper.createDataURI(simpleApp);


### PR DESCRIPTION
All status events now happen through JobService, NoOpEngineStatusCallback is used instead of EngineStatusCallbackImpl.