### PR TITLE
DB backend storage and startInactiveBackend function

### DIFF
--- a/rabix-engine/src/main/java/org/rabix/engine/memory/impl/InMemoryBackendRepository.java
+++ b/rabix-engine/src/main/java/org/rabix/engine/memory/impl/InMemoryBackendRepository.java
@@ -60,5 +60,13 @@ public class InMemoryBackendRepository implements BackendRepository{
   public synchronized Timestamp getHeartbeatInfo(UUID id) {
     return backendRepository.get(id).getHeartbeatInfo();
   }
+
+  @Override
+  public Backend getByName(String name) {
+    BackendEntity be = backendRepository.values().stream().filter(b -> b.getBackend().getName().equals(name)).findAny().orElse(null);
+    if (be == null)
+      return null;
+    return be.getBackend();
+  }
   
 }

--- a/rabix-engine/src/main/java/org/rabix/engine/repository/BackendRepository.java
+++ b/rabix-engine/src/main/java/org/rabix/engine/repository/BackendRepository.java
@@ -16,8 +16,10 @@ public interface BackendRepository {
   void insert(UUID id, Backend backend, Timestamp heartbeatInfo, BackendStatus status);
   
   void update(UUID id, Backend configuration);
-  
+
   Backend get(UUID id);
+  
+  Backend getByName(String name);
   
   List<Backend> getByStatus(BackendStatus status);
   

--- a/rabix-engine/src/main/java/org/rabix/engine/service/BackendService.java
+++ b/rabix-engine/src/main/java/org/rabix/engine/service/BackendService.java
@@ -10,8 +10,12 @@ import org.rabix.transport.backend.HeartbeatInfo;
 public interface BackendService {
 
   <T extends Backend> T create(T backend) throws BackendServiceException;
-  
+
   void startBackend(Backend backend) throws BackendServiceException;
+
+  void startInactiveBackend(UUID id) throws BackendServiceException;
+  
+  void startInactiveBackend(String name) throws BackendServiceException;
   
   void stopBackend(Backend backend) throws BackendServiceException;
   

--- a/rabix-engine/src/main/java/org/rabix/engine/service/impl/BackendServiceImpl.java
+++ b/rabix-engine/src/main/java/org/rabix/engine/service/impl/BackendServiceImpl.java
@@ -1,6 +1,7 @@
 package org.rabix.engine.service.impl;
 
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -140,6 +141,23 @@ public class BackendServiceImpl implements BackendService {
   @Override
   public void stopBackend(Backend backend) throws BackendServiceException {
     backendRepository.updateStatus(backend.getId(), BackendStatus.INACTIVE);
+  }
+
+  @Override
+  public void startInactiveBackend(UUID id) throws BackendServiceException {
+    backendRepository.updateHeartbeatInfo(id, Timestamp.from(Instant.now()));
+    backendRepository.updateStatus(id, BackendStatus.ACTIVE);    
+    Backend backend = backendRepository.get(id);
+    this.startBackend(backend);
+  }
+
+  @Override
+  public void startInactiveBackend(String name) throws BackendServiceException {
+    if(name==null)
+      throw new BackendServiceException("Can't start a backend without a name");
+    
+    Backend backend = backendRepository.getByName(name);
+    this.startInactiveBackend(backend.getId());
   }
   
 }

--- a/rabix-transport/src/main/java/org/rabix/transport/backend/Backend.java
+++ b/rabix-transport/src/main/java/org/rabix/transport/backend/Backend.java
@@ -2,16 +2,20 @@ package org.rabix.transport.backend;
 
 import java.util.UUID;
 
+import org.rabix.common.json.BeanPropertyView;
+import org.rabix.common.json.BeanSerializer;
 import org.rabix.transport.backend.impl.BackendActiveMQ;
 import org.rabix.transport.backend.impl.BackendLocal;
 import org.rabix.transport.backend.impl.BackendRabbitMQ;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonView;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes({ 
@@ -22,8 +26,10 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 public abstract class Backend {
 
   @JsonProperty("id")
+  @JsonView(BeanPropertyView.Full.class)
   protected UUID id;
   @JsonProperty("name")
+  @JsonView(BeanPropertyView.Full.class)
   protected String name;
   
   public static enum BackendType {
@@ -47,7 +53,8 @@ public abstract class Backend {
   public void setName(String name) {
     this.name = name;
   }
-  
+
+  @JsonView(BeanPropertyView.Full.class)
   public abstract BackendType getType();
 
   @Override
@@ -74,5 +81,10 @@ public abstract class Backend {
       return false;
     return true;
   }
-  
+
+  @JsonView(BeanPropertyView.Full.class)
+  @JsonIgnore
+  public String getConfiguration() {
+    return BeanSerializer.serializePartial(this);
+  }
 }

--- a/rabix-transport/src/main/java/org/rabix/transport/backend/impl/BackendActiveMQ.java
+++ b/rabix-transport/src/main/java/org/rabix/transport/backend/impl/BackendActiveMQ.java
@@ -2,22 +2,29 @@ package org.rabix.transport.backend.impl;
 
 import java.util.UUID;
 
+import org.rabix.common.json.BeanPropertyView;
 import org.rabix.transport.backend.Backend;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonView;
 
 public class BackendActiveMQ extends Backend {
 
   @JsonProperty("broker")
+  @JsonView(BeanPropertyView.Partial.class)
   private String broker;
   @JsonProperty("toBackendQueue")
+  @JsonView(BeanPropertyView.Partial.class)
   private String toBackendQueue;
   @JsonProperty("toBackendControlQueue")
+  @JsonView(BeanPropertyView.Partial.class)
   private String toBackendControlQueue;
   @JsonProperty("fromBackendQueue")
+  @JsonView(BeanPropertyView.Partial.class)
   private String fromBackendQueue;
   @JsonProperty("fromBackendHeartbeatQueue")
+  @JsonView(BeanPropertyView.Partial.class)
   private String fromBackendHeartbeatQueue;
   
   public BackendActiveMQ(@JsonProperty("id") UUID id, @JsonProperty("broker") String broker, @JsonProperty("toBackendQueue") String toBackendQueue, @JsonProperty("toBackendControlQueue") String toBackendControlQueue, @JsonProperty("fromBackendQueue") String fromBackendQueue, @JsonProperty("fromBackendHeartbeatQueue") String fromBackendHeartbeatQueue) {

--- a/rabix-transport/src/main/java/org/rabix/transport/backend/impl/BackendLocal.java
+++ b/rabix-transport/src/main/java/org/rabix/transport/backend/impl/BackendLocal.java
@@ -1,9 +1,11 @@
 package org.rabix.transport.backend.impl;
 
+import org.rabix.common.json.BeanPropertyView;
 import org.rabix.transport.backend.Backend;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonView;
 
 public class BackendLocal extends Backend {
 
@@ -13,12 +15,16 @@ public class BackendLocal extends Backend {
   public final static String RECEIVE_FROM_BACKEND_HEARTBEAT_QUEUE = "fromBackendHeartbeatQueue";
   
   @JsonProperty("to_backend_queue")
+  @JsonView(BeanPropertyView.Partial.class)
   private String toBackendQueue;
   @JsonProperty("to_backend_control_queue")
+  @JsonView(BeanPropertyView.Partial.class)
   private String toBackendControlQueue;
   @JsonProperty("from_backend_queue")
+  @JsonView(BeanPropertyView.Partial.class)
   private String fromBackendQueue;
   @JsonProperty("from_backend_heartbeat_queue")
+  @JsonView(BeanPropertyView.Partial.class)
   private String fromBackendHeartbeatQueue;
   
   public BackendLocal() {

--- a/rabix-transport/src/main/java/org/rabix/transport/backend/impl/BackendRabbitMQ.java
+++ b/rabix-transport/src/main/java/org/rabix/transport/backend/impl/BackendRabbitMQ.java
@@ -2,19 +2,24 @@ package org.rabix.transport.backend.impl;
 
 import java.util.UUID;
 
+import org.rabix.common.json.BeanPropertyView;
 import org.rabix.transport.backend.Backend;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonView;
 
 public class BackendRabbitMQ extends Backend {
 
   @JsonProperty("host")
+  @JsonView(BeanPropertyView.Partial.class)
   private String host;
   @JsonProperty("engine_configuration")
+  @JsonView(BeanPropertyView.Partial.class)
   private EngineConfiguration engineConfiguration;
   @JsonProperty("backend_configuration")
+  @JsonView(BeanPropertyView.Partial.class)
   private BackendConfiguration backendConfiguration;
   
   @JsonCreator


### PR DESCRIPTION
DB mapper used to serialize the entire backend object to configuration field, now only the fields from the specific implementations are serialized there.
Added a BackendService function to restart a backend based on its name or id