### PR TITLE
Fix/command line parts

### DIFF
--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/CWLCommandLineBuilder.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/CWLCommandLineBuilder.java
@@ -103,6 +103,10 @@ public class CWLCommandLineBuilder implements ProtocolCommandLineBuilder {
   private boolean getShellQuote(Object input) {
     return CWLBeanHelper.getValue(SHELL_QUOTE_KEY, input, true);
   }
+
+  private boolean isShellQuote(CWLJob job, Object input) {
+    return !job.isShellCommandEscapeEnabled() || getShellQuote(input);
+  }
   
   /**
    * Build command line arguments
@@ -318,7 +322,7 @@ public class CWLCommandLineBuilder implements ProtocolCommandLineBuilder {
       return new CWLCommandLinePart.Builder(position, isFile).keyValue(keyValue).parts(prefixedValues).build();
     }
 
-    boolean shellQuote = getShellQuote(inputBinding);
+    boolean shellQuote = isShellQuote(job, inputBinding);
 
     if (prefix == null) {
       return new CWLCommandLinePart.Builder(position, isFile).keyValue(keyValue).part(new CommandLine.Part(value.toString(), shellQuote)).build();

--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/CWLCommandLineBuilder.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/CWLCommandLineBuilder.java
@@ -77,7 +77,10 @@ public class CWLCommandLineBuilder implements ProtocolCommandLineBuilder {
     } catch (CWLExpressionException e) {
       throw new BindingException("Failed to extract standard error.", e);
     }
-    CommandLine commandLine = new CommandLine(buildCommandLineParts(cwlJob, workingDir, filePathMapper), stdin, stdout, stderr);
+
+    boolean runInShell = cwlJob.isShellCommandEscapeEnabled();
+
+    CommandLine commandLine = new CommandLine(buildCommandLineParts(cwlJob, workingDir, filePathMapper), stdin, stdout, stderr, runInShell);
     logger.info("Command line built. CommandLine = {}", commandLine);
     return commandLine;
   }

--- a/rabix-bindings-draft2/src/main/java/org/rabix/bindings/draft2/Draft2CommandLineBuilder.java
+++ b/rabix-bindings-draft2/src/main/java/org/rabix/bindings/draft2/Draft2CommandLineBuilder.java
@@ -60,7 +60,7 @@ public class Draft2CommandLineBuilder implements ProtocolCommandLineBuilder {
       throw new BindingException("Failed to extract standard outputs.", e);
     }
 
-    CommandLine commandLine = new CommandLine(commandLineParts, stdin, stdout, null);
+    CommandLine commandLine = new CommandLine(commandLineParts, stdin, stdout, null, true);
     logger.info("Command line built. CommandLine = {}", commandLine);
     return commandLine;
   }

--- a/rabix-bindings-draft2/src/main/java/org/rabix/bindings/draft2/Draft2CommandLineBuilder.java
+++ b/rabix-bindings-draft2/src/main/java/org/rabix/bindings/draft2/Draft2CommandLineBuilder.java
@@ -43,11 +43,8 @@ public class Draft2CommandLineBuilder implements ProtocolCommandLineBuilder {
     }
     
     Draft2CommandLineTool commandLineTool = (Draft2CommandLineTool) draft2Job.getApp();
-    List<String> commandLineParts = Lists.transform(buildCommandLineParts(draft2Job, workingDir, filePathMapper), new Function<Object, String>() {
-      public String apply(Object obj) {
-        return obj.toString();
-      }
-    });
+    List<CommandLine.Part> commandLineParts = Lists.transform(buildCommandLineParts(draft2Job, workingDir, filePathMapper), (obj ->
+        new CommandLine.Part(obj.toString())));
 
     String stdin = null;
     try {

--- a/rabix-bindings-draft2/src/test/java/org/rabix/bindings/draft2/bean/Draft2CommandLineToolTest.java
+++ b/rabix-bindings-draft2/src/test/java/org/rabix/bindings/draft2/bean/Draft2CommandLineToolTest.java
@@ -25,14 +25,14 @@ public class Draft2CommandLineToolTest {
 
     Draft2Job draft2Job = BeanSerializer.deserialize(inputJson, Draft2Job.class);
 
-    List<Object> expectedList = new LinkedList<Object>();
+    List<String> expectedList = new LinkedList<String>();
     expectedList.add("bwa");
     expectedList.add("mem");
     expectedList.add("rabix/tests/test-files/chr20.fa");
     expectedList.add("-XXX");
     expectedList.add("-YYY rabix/tests/test-files/example_human_Illumina.pe_1.fastq -YYY rabix/tests/test-files/example_human_Illumina.pe_2.fastq");
 
-    List<?> resultList;
+    List<String> resultList;
     try {
       String encodedApp = URIHelper.createDataURI(BeanSerializer.serializeFull(draft2Job.getApp()));
       Job job = new Job(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), "id", encodedApp, null, null, draft2Job.getInputs(), null, null, null, null);

--- a/rabix-bindings-draft3/src/main/java/org/rabix/bindings/draft3/Draft3CommandLineBuilder.java
+++ b/rabix-bindings-draft3/src/main/java/org/rabix/bindings/draft3/Draft3CommandLineBuilder.java
@@ -52,11 +52,8 @@ public class Draft3CommandLineBuilder implements ProtocolCommandLineBuilder {
     }
     
     Draft3CommandLineTool commandLineTool = (Draft3CommandLineTool) draft3Job.getApp();
-    List<String> commandLineParts = Lists.transform(buildCommandLineParts(draft3Job, workingDir, filePathMapper), new Function<Object, String>() {
-      public String apply(Object obj) {
-        return obj.toString();
-      }
-    });
+    List<CommandLine.Part> commandLineParts = Lists.transform(buildCommandLineParts(draft3Job, workingDir, filePathMapper), (obj ->
+        new CommandLine.Part(obj.toString())));
 
     String stdin = null;
     try {

--- a/rabix-bindings-draft3/src/main/java/org/rabix/bindings/draft3/Draft3CommandLineBuilder.java
+++ b/rabix-bindings-draft3/src/main/java/org/rabix/bindings/draft3/Draft3CommandLineBuilder.java
@@ -69,7 +69,7 @@ public class Draft3CommandLineBuilder implements ProtocolCommandLineBuilder {
       throw new BindingException("Failed to extract standard outputs.", e);
     }
 
-    CommandLine commandLine = new CommandLine(commandLineParts, stdin, stdout, null);
+    CommandLine commandLine = new CommandLine(commandLineParts, stdin, stdout, null, true);
     logger.info("Command line built. CommandLine = {}", commandLine);
     return commandLine;
   }

--- a/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/SBCommandLineBuilder.java
+++ b/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/SBCommandLineBuilder.java
@@ -45,11 +45,7 @@ public class SBCommandLineBuilder implements ProtocolCommandLineBuilder {
     }
     
     SBCommandLineTool commandLineTool = (SBCommandLineTool) sbJob.getApp();
-    List<String> commandLineParts = Lists.transform(buildCommandLineParts(sbJob, workingDir, filePathMapper), new Function<Object, String>() {
-      public String apply(Object obj) {
-        return obj.toString();
-      }
-    });
+    List<CommandLine.Part> commandLineParts = Lists.transform(buildCommandLineParts(sbJob, workingDir, filePathMapper), (obj -> new CommandLine.Part(obj.toString())));
 
     String stdin = null;
     try {

--- a/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/SBCommandLineBuilder.java
+++ b/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/SBCommandLineBuilder.java
@@ -61,7 +61,7 @@ public class SBCommandLineBuilder implements ProtocolCommandLineBuilder {
       throw new BindingException("Failed to extract standard outputs.", e);
     }
 
-    CommandLine commandLine = new CommandLine(commandLineParts, stdin, stdout, null);
+    CommandLine commandLine = new CommandLine(commandLineParts, stdin, stdout, null, true);
     logger.info("Command line built. CommandLine = {}", commandLine);
     return commandLine;
   }

--- a/rabix-bindings/src/main/java/org/rabix/bindings/CommandLine.java
+++ b/rabix-bindings/src/main/java/org/rabix/bindings/CommandLine.java
@@ -15,20 +15,22 @@ public class CommandLine {
   private final String standardIn;
   private final String standardOut;
   private final String standardError;
+
+  private final boolean runInShell;
   
-  public CommandLine(List<Part> parts, String standardIn, String standardOut, String standardError) {
+  public CommandLine(List<Part> parts, String standardIn, String standardOut, String standardError, boolean runInShell) {
     this.parts = parts;
     this.standardIn = standardIn;
     this.standardOut = standardOut;
     this.standardError = standardError;
+    this.runInShell = runInShell;
   }
 
   public String build() {
     StringBuilder builder = new StringBuilder();
    
     for (Part part : parts) {
-      String value = part.isQuote() ? EncodingHelper.shellQuote(part.getValue()): part.getValue();
-      builder.append(value).append(PART_SEPARATOR);
+      builder.append(part.toString()).append(PART_SEPARATOR);
     }
     if (!StringUtils.isEmpty(standardIn)) {
       builder.append(PART_SEPARATOR).append("<").append(PART_SEPARATOR).append(standardIn);
@@ -62,6 +64,10 @@ public class CommandLine {
     return standardError;
   }
 
+  public boolean isRunInShell() {
+    return runInShell;
+  }
+
   @Override
   public String toString() {
     return "CommandLine [parts=" + parts + ", standardIn=" + standardIn + ", standardOut=" + standardOut + ", standardError=" + standardError + "]";
@@ -86,6 +92,10 @@ public class CommandLine {
 
     public boolean isQuote() {
       return quote;
+    }
+
+    public String toString() {
+      return quote ? EncodingHelper.shellQuote(value): value;
     }
   }
   

--- a/rabix-bindings/src/main/java/org/rabix/bindings/CommandLine.java
+++ b/rabix-bindings/src/main/java/org/rabix/bindings/CommandLine.java
@@ -1,20 +1,22 @@
 package org.rabix.bindings;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
+import org.rabix.common.helper.EncodingHelper;
 
 public class CommandLine {
 
   public static final String PART_SEPARATOR = "\u0020";
   
-  private final List<String> parts;
+  private final List<Part> parts;
   
   private final String standardIn;
   private final String standardOut;
   private final String standardError;
   
-  public CommandLine(List<String> parts, String standardIn, String standardOut, String standardError) {
+  public CommandLine(List<Part> parts, String standardIn, String standardOut, String standardError) {
     this.parts = parts;
     this.standardIn = standardIn;
     this.standardOut = standardOut;
@@ -24,8 +26,9 @@ public class CommandLine {
   public String build() {
     StringBuilder builder = new StringBuilder();
    
-    for (String part : parts) {
-      builder.append(part).append(PART_SEPARATOR);
+    for (Part part : parts) {
+      String value = part.isQuote() ? EncodingHelper.shellQuote(part.getValue()): part.getValue();
+      builder.append(value).append(PART_SEPARATOR);
     }
     if (!StringUtils.isEmpty(standardIn)) {
       builder.append(PART_SEPARATOR).append("<").append(PART_SEPARATOR).append(standardIn);
@@ -44,7 +47,7 @@ public class CommandLine {
   }
   
   public List<String> getParts() {
-    return parts;
+    return parts.stream().map(Part::getValue).collect(Collectors.toList());
   }
 
   public String getStandardIn() {
@@ -62,6 +65,28 @@ public class CommandLine {
   @Override
   public String toString() {
     return "CommandLine [parts=" + parts + ", standardIn=" + standardIn + ", standardOut=" + standardOut + ", standardError=" + standardError + "]";
+  }
+
+  public static class Part {
+    private String value;
+    private boolean quote;
+
+    public Part(String value) {
+      this.value = value;
+    }
+
+    public Part(String value, boolean quote) {
+      this.value = value;
+      this.quote = quote;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    public boolean isQuote() {
+      return quote;
+    }
   }
   
 }

--- a/rabix-common/src/main/java/org/rabix/common/helper/EncodingHelper.java
+++ b/rabix-common/src/main/java/org/rabix/common/helper/EncodingHelper.java
@@ -25,12 +25,9 @@ public class EncodingHelper {
   }
   
   public static String shellQuote(String argument) {
-    System.out.println("shellQuote " + argument);
-
     if (!NEEDS_QUOTING_PATTERN.matcher(argument).find()) {
       return argument;
     }
-    System.out.println("escaping " + argument);
     return "'" + argument.replace("'", "'\\''") + "'";
   }
 

--- a/rabix-common/src/main/java/org/rabix/common/helper/EncodingHelper.java
+++ b/rabix-common/src/main/java/org/rabix/common/helper/EncodingHelper.java
@@ -24,31 +24,30 @@ public class EncodingHelper {
     return new String(dataBytes, DEFAULT_ENCODING);
   }
   
-  public static Object shellQuote(Object argument) {
-    if (argument == null) {
-      return null;
-    }
-    if (!(argument instanceof String)) {
+  public static String shellQuote(String argument) {
+    System.out.println("shellQuote " + argument);
+
+    if (!NEEDS_QUOTING_PATTERN.matcher(argument).find()) {
       return argument;
     }
-    String argumentStr = (String) argument;
-    if (!NEEDS_QUOTING_PATTERN.matcher(argumentStr).find()) {
-      return argumentStr;
-    }
-    return "'" + argumentStr.replace("'", "'\\''") + "'";
+    System.out.println("escaping " + argument);
+    return "'" + argument.replace("'", "'\\''") + "'";
   }
 
-  public static String shellUnquote(String argument) {
-    if (argument == null) {
-      return null;
-    }
-
-    if (!argument.startsWith("'") && !argument.endsWith("'")) {
-      return argument;
-    }
-
-    return argument.substring(1, argument.length() - 1).replace("'\\''", "'");
-
-  }
+//  public static String shellUnquote(String argument) {
+//    System.out.println("shellUnquote " + argument);
+//    if (argument == null) {
+//      return null;
+//    }
+//
+//    if (!argument.startsWith("'") && !argument.endsWith("'")) {
+//      return argument;
+//    }
+//    String res = argument.substring(1, argument.length() - 1).replace("'\\''", "'");
+//    System.out.println("unescaping " + argument);
+//    System.out.println(res);
+//    return res;
+//
+//  }
   
 }

--- a/rabix-executor/src/main/java/org/rabix/executor/container/impl/LocalContainerHandler.java
+++ b/rabix-executor/src/main/java/org/rabix/executor/container/impl/LocalContainerHandler.java
@@ -95,16 +95,18 @@ public class LocalContainerHandler implements ContainerHandler {
         }
       }
 
-      VerboseLogger.log(String.join(" ", commandLine.getParts()));
-
-      List<String> parts = commandLine.getParts();
-      processBuilder.command(parts);
-
       processBuilder.directory(workingDir);
 
-      processBuilder.redirectInput(redirect(workingDir, commandLine.getStandardIn(), false));
-      processBuilder.redirectOutput(redirect(workingDir, commandLine.getStandardOut(), true));
-      processBuilder.redirectError(redirect(workingDir, commandLine.getStandardError(), true));
+      if (!commandLine.isRunInShell()) {
+        List<String> parts = commandLine.getParts();
+        processBuilder.command(parts);
+
+        processBuilder.redirectInput(redirect(workingDir, commandLine.getStandardIn(), false));
+        processBuilder.redirectOutput(redirect(workingDir, commandLine.getStandardOut(), true));
+        processBuilder.redirectError(redirect(workingDir, commandLine.getStandardError(), true));
+      } else {
+        processBuilder.command("/bin/sh", "-c", commandLineString);
+      }
 
       VerboseLogger.log(String.format("Running command line: %s", commandLineString));
       processFuture = executorService.submit(new Callable<Integer>() {

--- a/rabix-integration-testing/src/main/java/org/rabix/tests/TestRunner.java
+++ b/rabix-integration-testing/src/main/java/org/rabix/tests/TestRunner.java
@@ -37,27 +37,23 @@ public class TestRunner {
   private static String[] drafts = { "draft-sb", "draft-2", "draft-3", "cwl" };
   private static final Logger logger = LoggerFactory.getLogger(TestRunner.class);
 
-  public static void main(String[] commandLineArguments) throws IOException {
-    try {
-      PropertiesConfiguration configuration = getConfig();
-      setupIntegrationCommandPrefix(configuration);
-      extractBuildFile();
-      copyTestsInWorkingDir();
+  public static void main(String[] commandLineArguments) throws Exception {
+    PropertiesConfiguration configuration = getConfig();
+    setupIntegrationCommandPrefix(configuration);
+    extractBuildFile();
+    copyTestsInWorkingDir();
 
-      for (String draft : drafts) {
-        draftName = draft;
-        startIntegrationTests(draftName);
+    for (String draft : drafts) {
+      draftName = draft;
+      startIntegrationTests(draftName);
 
-        if (draftName.equals("cwl")) {
-          startConformanceTests(draftName);
-        }
+      if (draftName.equals("cwl")) {
+        startConformanceTests(draftName);
       }
-    } catch (RabixTestException e) {
-      logger.error("Error occuerred:", e);
     }
   }
 
-  private static void startConformanceTests(String draftName) throws RabixTestException {
+  private static void startConformanceTests(String draftName) throws Exception {
     logger.info("Conformance tests started:  " + draftName);
     PropertiesConfiguration configuration = getConfig();
     cwlTestWorkingdir = getStringFromConfig(configuration, draftName);
@@ -135,9 +131,9 @@ public class TestRunner {
           File integrationTempResultFile = new File(integrationTempResultPath);
 
           String resultText = readFile(integrationTempResultFile.getAbsolutePath(), Charset.defaultCharset());
-          Map<String, Object> actualResult = JSONHelper.readMap(JSONHelper.transformToJSON(resultText));
           logger.info("\nGenerated result file:");
           logger.info(resultText);
+          Map<String, Object> actualResult = JSONHelper.readMap(JSONHelper.transformToJSON(resultText));
           testPassed = validateTestCase(currentTestDetails, actualResult);
           logger.info("Test result: ");
           if (testPassed) {
@@ -340,9 +336,8 @@ public class TestRunner {
     }
   }
 
-  public static void executeConformanceSuite(final String cmdline, final String directory) throws RabixTestException {
-    try {
-      ProcessBuilder processBuilder = new ProcessBuilder(new String[] { "bash", "-c", cmdline }).inheritIO()
+  public static void executeConformanceSuite(final String cmdline, final String directory) throws Exception {
+    ProcessBuilder processBuilder = new ProcessBuilder(new String[] { "bash", "-c", cmdline }).inheritIO()
           .directory(new File(directory));
 
       Map<String, String> env = processBuilder.environment();
@@ -354,13 +349,10 @@ public class TestRunner {
       int exitCode = process.waitFor();
 
       if (0 != exitCode) {
-        throw new RabixTestException("Error while executing command: Non zero exit code " + exitCode);
+        logger.error("Error while executing command: Non zero exit code " + exitCode);
+        System.exit(exitCode);
       }
 
-    } catch (Exception e) {
-      logger.error("Error while executing command. ", e);
-      throw new RabixTestException("Error while executing command: " + e.getMessage());
-    }
   }
 
   /**


### PR DESCRIPTION
Changed CommanLine object to consist of Parts instead of strings, plus explicit `runInShell` flag. Older drafts should keep their behavior, while v1 should be fully conformant. Fixes #204 