### PR TITLE
Discover secondary files for inputs (#211)

### DIFF
--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/CWLProcessor.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/CWLProcessor.java
@@ -470,9 +470,6 @@ public class CWLProcessor implements ProtocolProcessor {
             CWLFileValueHelper.setChecksum(secondaryFile, secondaryFileMap, hashAlgorithm);
           }
         }
-        else {
-          throw new IOException(String.format("secondary file not found: %s", secondaryFile));
-        }
       } else if (expr instanceof Map) {
         secondaryFileMap = (Map<String, Object>) expr;
         postprocessCreatedResults(secondaryFileMap, hashAlgorithm, workingDir);

--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/CWLProcessor.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/CWLProcessor.java
@@ -498,23 +498,14 @@ public class CWLProcessor implements ProtocolProcessor {
   }
 
   private Map<String, Object> getInputSecondaryFiles(CWLJob job, Map<String, Object> inputs, File workingDir) throws BindingException {
-    CWLCommandLineTool commandLineTool = (CWLCommandLineTool) job.getApp();
-    List<CWLInputPort> inputPorts = commandLineTool.getInputs();
+    CWLJobApp jobApp = job.getApp();
 
     final Map<String, Object> result = new HashMap<>();
     for (Map.Entry<String, Object> input: inputs.entrySet()) {
       String key = input.getKey();
       Object value = input.getValue();
-      int i = 0;
       try {
-        CWLInputPort inputPort = null;
-        for (CWLInputPort ip: inputPorts) {
-          String id = ip.getId();
-          if (Objects.equals(id, key)) {
-              inputPort = ip;
-              break;
-          }
-        }
+        CWLInputPort inputPort = jobApp.getInput(key);
         List<?> secondaryFiles = getSecondaryFiles(job, null, inputs, CWLFileValueHelper.getLocation(value), inputPort.getSecondaryFiles(), workingDir);
         if (secondaryFiles != null) {
           CWLFileValueHelper.setSecondaryFiles(secondaryFiles, value);
@@ -523,7 +514,6 @@ public class CWLProcessor implements ProtocolProcessor {
       } catch (Exception e) {
         throw new BindingException("Failed to extract secondary files.", e);
       }
-      i++;
     }
     return result;
   }

--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/CWLProcessor.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/CWLProcessor.java
@@ -68,12 +68,12 @@ public class CWLProcessor implements ProtocolProcessor {
     try {
       Map<String, Object> inputs = cwlJob.getInputs();
 
-      inputs = getInputFileData(cwlJob, null, inputs, workingDir);
       inputs = portProcessorHelper.createFileLiteralFiles(inputs, workingDir);
       inputs = portProcessorHelper.setPathsToInputs(inputs);
       inputs = portProcessorHelper.setFileProperties(inputs);
       inputs = portProcessorHelper.loadInputContents(inputs);
       inputs = portProcessorHelper.stageInputFiles(inputs, workingDir);
+      inputs = getInputSecondaryFiles(cwlJob, inputs, workingDir);
       Job newJob = Job.cloneWithResources(job, CWLRuntimeHelper.convertToResources(runtime));
       
       @SuppressWarnings("unchecked")
@@ -497,7 +497,7 @@ public class CWLProcessor implements ProtocolProcessor {
     }
   }
 
-  private Map<String, Object> getInputFileData(CWLJob job, HashAlgorithm hashAlgorithm, Map<String, Object> inputs, File workingDir) throws BindingException {
+  private Map<String, Object> getInputSecondaryFiles(CWLJob job, Map<String, Object> inputs, File workingDir) throws BindingException {
     CWLCommandLineTool commandLineTool = (CWLCommandLineTool) job.getApp();
     List<CWLInputPort> inputPorts = commandLineTool.getInputs();
 
@@ -515,7 +515,7 @@ public class CWLProcessor implements ProtocolProcessor {
               break;
           }
         }
-        List<?> secondaryFiles = getSecondaryFiles(job, hashAlgorithm, inputs, CWLFileValueHelper.getLocation(value), inputPort.getSecondaryFiles(), workingDir);
+        List<?> secondaryFiles = getSecondaryFiles(job, null, inputs, CWLFileValueHelper.getLocation(value), inputPort.getSecondaryFiles(), workingDir);
         if (secondaryFiles != null) {
           CWLFileValueHelper.setSecondaryFiles(secondaryFiles, value);
         }

--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/bean/CWLEmbeddedApp.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/bean/CWLEmbeddedApp.java
@@ -30,7 +30,7 @@ public class CWLEmbeddedApp extends CWLJobApp {
         @Override
         public CWLInputPort apply(ApplicationPort port) {
           return new CWLInputPort(port.getId(), port.getDefaultValue(), port.getSchema(), null, null, null,
-              port.getScatter(), null, port.getLinkMerge(), port.getDescription());
+              port.getScatter(), null, port.getLinkMerge(), port.getDescription(), null);
         }
       });
       outputs = Lists.transform(application.getOutputs(), new Function<ApplicationPort, CWLOutputPort>() {

--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/bean/CWLInputPort.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/bean/CWLInputPort.java
@@ -39,22 +39,24 @@ public class CWLInputPort extends ApplicationPort {
   protected Object format;
   @JsonProperty("streamable")
   protected Boolean streamable;
-  
   @JsonProperty("sbg:stageInput")
   protected final String stageInput;
   @JsonProperty("inputBinding")
   protected final Object inputBinding;
+  @JsonProperty("secondaryFiles")
+  protected Object secondaryFiles;
 
   @JsonCreator
   public CWLInputPort(@JsonProperty("id") String id, @JsonProperty("default") Object defaultValue, @JsonProperty("type") Object schema, 
       @JsonProperty("inputBinding") Object inputBinding, @JsonProperty("streamable") Boolean streamable, @JsonProperty("format") Object format,
       @JsonProperty("scatter") Boolean scatter, @JsonProperty("sbg:stageInput") String stageInput, @JsonProperty("linkMerge") String linkMerge,
-                      @JsonProperty("description") String description) {
+                      @JsonProperty("description") String description, @JsonProperty("secondaryFiles") Object secondaryFiles) {
     super(id, defaultValue, schema, scatter, linkMerge, description);
     this.format = format;
     this.streamable = streamable;
     this.stageInput = stageInput;
     this.inputBinding = inputBinding;
+    this.secondaryFiles = secondaryFiles;
   }
 
   @Override
@@ -65,6 +67,10 @@ public class CWLInputPort extends ApplicationPort {
   
   public Object getInputBinding() {
     return inputBinding;
+  }
+
+  public Object getSecondaryFiles() {
+    return secondaryFiles;
   }
 
   public String getStageInput() {

--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/json/CWLInputPortsDeserializer.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/json/CWLInputPortsDeserializer.java
@@ -38,13 +38,13 @@ public class CWLInputPortsDeserializer extends JsonDeserializer<List<CWLInputPor
         CWLInputPort inputPort = null;
         if (subnodeEntry.getValue().isObject()) {
           if(subnodeEntry.getValue().has("type") && subnodeEntry.getValue().get("type").equals("record")) {
-            inputPort = new CWLInputPort(subnodeEntry.getKey(), null, JSONHelper.transform(subnodeEntry.getValue()), null, null, null, null, null, null, null);
+            inputPort = new CWLInputPort(subnodeEntry.getKey(), null, JSONHelper.transform(subnodeEntry.getValue()), null, null, null, null, null, null, null, null);
           } else {
             inputPort = BeanSerializer.deserialize(subnodeEntry.getValue().toString(), CWLInputPort.class);
             inputPort.setId(subnodeEntry.getKey());
           }
         } else {
-          inputPort = new CWLInputPort(subnodeEntry.getKey(), null, JSONHelper.transform(subnodeEntry.getValue()), null, null, null, null, null, null, null);
+          inputPort = new CWLInputPort(subnodeEntry.getKey(), null, JSONHelper.transform(subnodeEntry.getValue()), null, null, null, null, null, null, null, null);
         }
         inputPorts.add(inputPort);
       }


### PR DESCRIPTION
Should address #211 

I only fixed this in the CWL 1.0 bindings.  I wanted to get feedback on my approach before doing anything else. 