### PR TITLE
Deletes events from an aborted or failed context

### DIFF
--- a/rabix-engine/src/main/java/org/rabix/engine/processor/handler/impl/JobStatusEventHandler.java
+++ b/rabix-engine/src/main/java/org/rabix/engine/processor/handler/impl/JobStatusEventHandler.java
@@ -206,6 +206,7 @@ public class JobStatusEventHandler implements EventHandler<JobStatusEvent> {
       if (jobRecord.isRoot()) {
         try {
           Job rootJob = JobHelper.createRootJob(jobRecord, JobStatus.FAILED, jobRecordService, variableRecordService, linkRecordService, contextRecordService, dagNodeDB, appDB, null);
+          rootJob = Job.cloneWithMessage(rootJob, event.getMessage());
           jobService.handleJobRootFailed(rootJob);
           
           eventProcessor.send(new ContextStatusEvent(event.getContextId(), ContextStatus.FAILED));
@@ -215,9 +216,10 @@ public class JobStatusEventHandler implements EventHandler<JobStatusEvent> {
       } else {
         try {
           Job failedJob = JobHelper.createCompletedJob(jobRecord, JobStatus.FAILED, jobRecordService, variableRecordService, linkRecordService, contextRecordService, dagNodeDB, appDB);
+          failedJob = Job.cloneWithMessage(failedJob, event.getMessage());
           jobService.handleJobFailed(failedJob);
           
-          eventProcessor.send(new JobStatusEvent(InternalSchemaHelper.ROOT_NAME, event.getContextId(), JobState.FAILED, event.getEventGroupId(), event.getProducedByNode()));
+          eventProcessor.send(new JobStatusEvent(InternalSchemaHelper.ROOT_NAME, event.getContextId(), JobState.FAILED, event.getMessage(), event.getEventGroupId(), event.getProducedByNode()));
         } catch (Exception e) {
           throw new EventHandlerException("Failed to call onFailed callback for Job " + jobRecord.getId(), e);
         }

--- a/rabix-engine/src/main/java/org/rabix/engine/processor/impl/EventProcessorImpl.java
+++ b/rabix-engine/src/main/java/org/rabix/engine/processor/impl/EventProcessorImpl.java
@@ -91,6 +91,7 @@ public class EventProcessorImpl implements EventProcessor {
               @Override
               public Void call() throws TransactionException {
                 if (!handle(eventReference.get())) {
+                  eventRepository.delete(eventReference.get().getEventGroupId());
                   return null;
                 }
                 cacheService.flush(eventReference.get().getContextId());

--- a/rabix-engine/src/main/java/org/rabix/engine/service/impl/JobServiceImpl.java
+++ b/rabix-engine/src/main/java/org/rabix/engine/service/impl/JobServiceImpl.java
@@ -320,44 +320,7 @@ public class JobServiceImpl implements JobService {
   @Override
   public void handleJobFailed(final Job failedJob){
     logger.warn("Job {}, rootId: {} failed: {}", failedJob.getName(), failedJob.getRootId(), failedJob.getMessage());
-    if (isLocalBackend) {
-      synchronized (stoppingRootIds) {
-        if (stoppingRootIds.contains(failedJob.getRootId())) {
-          return;
-        }
-        stoppingRootIds.add(failedJob.getRootId());
 
-        try {
-          stop(failedJob.getRootId());
-        } catch (JobServiceException e) {
-          logger.error("Failed to stop Root job " + failedJob.getRootId(), e);
-        }
-        executorService.submit(new Runnable() {
-          @Override
-          public void run() {
-            while (true) {
-              try {
-                boolean exit = true;
-                for (Job job : jobRepository.getByRootId(failedJob.getRootId())) {
-                  if (!job.isRoot() && !isFinished(job.getStatus())) {
-                    exit = false;
-                    break;
-                  }
-                }
-                if (exit) {
-                  handleJobRootFailed(failedJob);
-                  break;
-                }
-                Thread.sleep(TimeUnit.SECONDS.toMillis(2));
-              } catch (Exception e) {
-                logger.error("Failed to stop root Job " + failedJob.getRootId(), e);
-                break;
-              }
-            }
-          }
-        });
-      }
-    }
     if (deleteIntermediaryFiles) {
       intermediaryFilesService.handleJobFailed(failedJob, jobRepository.get(failedJob.getRootId()), keepInputFiles);
     }
@@ -368,16 +331,6 @@ public class JobServiceImpl implements JobService {
     }
   }
 
-  private boolean isFinished(JobStatus jobStatus) {
-    switch (jobStatus) {
-      case COMPLETED:
-      case FAILED:
-      case ABORTED:
-        return true;
-      default:
-        return false;
-    }
-  }
   @Override
   public void handleJobContainerReady(Job containerJob) {
     logger.info("Container job {} rootId: {} id ready.", containerJob.getName(), containerJob.getRootId());


### PR DESCRIPTION
Events for a job failing were never updated to a status different from UNPROCESSED so they were always skipped on every engine start

Also Removed Duplicate code for root job failed
Also Added messages to event sending