### PR TITLE
Bug/infinite cache

### DIFF
--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/CWLAppProcessor.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/CWLAppProcessor.java
@@ -11,18 +11,20 @@ import org.rabix.bindings.cwl.helper.CWLSchemaHelper;
 import org.rabix.bindings.cwl.resolver.CWLDocumentResolver;
 import org.rabix.bindings.model.Application;
 import org.rabix.bindings.model.Job;
-import org.rabix.common.json.BeanSerializer;
+import org.rabix.common.helper.JSONHelper;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 public class CWLAppProcessor implements ProtocolAppProcessor {
 
   @Override
-  public String loadApp(String uri) throws BindingException {
+  public JsonNode loadApp(String uri) throws BindingException {
     return CWLDocumentResolver.resolve(uri);
   }
   
   @Override
   public Application loadAppObject(String app) throws BindingException {
-    return BeanSerializer.deserialize(loadApp(app), CWLJobApp.class);
+    return JSONHelper.readObject(loadApp(app), CWLJobApp.class);
   }
 
   @Override

--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/CWLBindings.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/CWLBindings.java
@@ -30,6 +30,8 @@ import org.rabix.bindings.model.requirement.Requirement;
 import org.rabix.bindings.model.requirement.ResourceRequirement;
 import org.rabix.common.helper.ChecksumHelper.HashAlgorithm;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 public class CWLBindings implements Bindings {
 
   private final ProtocolType protocolType;
@@ -54,7 +56,7 @@ public class CWLBindings implements Bindings {
   }
   
   @Override
-  public String loadApp(String uri) throws BindingException {
+  public JsonNode loadApp(String uri) throws BindingException {
     return appProcessor.loadApp(uri);
   }
   

--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/helper/CWLJobHelper.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/helper/CWLJobHelper.java
@@ -11,14 +11,13 @@ import org.rabix.bindings.cwl.bean.CWLRuntime;
 import org.rabix.bindings.cwl.expression.CWLExpressionException;
 import org.rabix.bindings.cwl.resolver.CWLDocumentResolver;
 import org.rabix.bindings.model.Job;
-import org.rabix.common.json.BeanSerializer;
+import org.rabix.common.helper.JSONHelper;
 
 public class CWLJobHelper {
 
   @SuppressWarnings("unchecked")
   public static CWLJob getCWLJob(Job job) throws BindingException {
-    String resolvedAppStr = CWLDocumentResolver.resolve(job.getApp());
-    CWLJobApp app = BeanSerializer.deserialize(resolvedAppStr, CWLJobApp.class);
+    CWLJobApp app = JSONHelper.readObject(CWLDocumentResolver.resolve(job.getApp()), CWLJobApp.class);
 
     Map<String, Object> nativeInputs = (Map<String, Object>) CWLValueTranslator.translateToSpecific(job.getInputs());
     Map<String, Object> nativeOutputs = (Map<String, Object>) CWLValueTranslator.translateToSpecific(job.getOutputs());

--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/resolver/CWLDocumentResolver.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/resolver/CWLDocumentResolver.java
@@ -14,8 +14,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.NotImplementedException;
@@ -88,19 +86,14 @@ public class CWLDocumentResolver {
   public static final String DOCUMENT_FRAGMENT_SEPARATOR = "#";
 
   private static final String DEFAULT_ENCODING = "UTF-8";
-
-  private static ConcurrentMap<String, String> cache = new ConcurrentHashMap<>();
+  
   private static boolean graphResolve = false;
 
   private static Map<String, String> namespaces = new HashMap<String, String>();
   private static Map<String, Map<String, CWLDocumentResolverReference>> referenceCache = new HashMap<>();
   private static Map<String, List<CWLDocumentResolverReplacement>> replacements = new HashMap<>();
 
-  public static String resolve(String appUrl) throws BindingException {
-    if (cache.containsKey(appUrl)) {
-      return cache.get(appUrl);
-    }
-
+  public static JsonNode resolve(String appUrl) throws BindingException {
     String appUrlBase = appUrl;
     if (!URIHelper.isData(appUrl)) {
       appUrlBase = URIHelper.extractBase(appUrl);
@@ -183,7 +176,6 @@ public class CWLDocumentResolver {
           Map<String, Object> result = JSONHelper.readMap(elem);
           result.put(CWL_VERSION_KEY, cwlVersion);
           root = JSONHelper.convertToJsonNode(result);
-          cache.put(appUrl, JSONHelper.writeObject(root));
           break;
         }
       }
@@ -194,16 +186,14 @@ public class CWLDocumentResolver {
         clearReferenceCache(appUrl);
         throw new BindingException("Document version is not v1.0");
       }
-      cache.put(appUrl, JSONHelper.writeObject(root));
     }
     clearReplacements(appUrl);
     clearReferenceCache(appUrl);
 
     if (rewriteDefaultPaths) {
       addAppLocations(root, appUrl);
-      cache.put(appUrl, JSONHelper.writeObject(root));
     }
-    return cache.get(appUrl);
+    return root;
   }
 
   private static void addAppLocations(JsonNode node, String previous) {

--- a/rabix-bindings-draft2/src/main/java/org/rabix/bindings/draft2/Draft2AppProcessor.java
+++ b/rabix-bindings-draft2/src/main/java/org/rabix/bindings/draft2/Draft2AppProcessor.java
@@ -11,18 +11,20 @@ import org.rabix.bindings.draft2.helper.Draft2SchemaHelper;
 import org.rabix.bindings.draft2.resolver.Draft2DocumentResolver;
 import org.rabix.bindings.model.Application;
 import org.rabix.bindings.model.Job;
-import org.rabix.common.json.BeanSerializer;
+import org.rabix.common.helper.JSONHelper;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 public class Draft2AppProcessor implements ProtocolAppProcessor {
 
   @Override
-  public String loadApp(String uri) throws BindingException {
+  public JsonNode loadApp(String uri) throws BindingException {
     return Draft2DocumentResolver.resolve(uri);
   }
   
   @Override
   public Application loadAppObject(String app) throws BindingException {
-    return BeanSerializer.deserialize(loadApp(app), Draft2JobApp.class);
+    return JSONHelper.readObject(loadApp(app), Draft2JobApp.class);
   }
 
   @Override

--- a/rabix-bindings-draft2/src/main/java/org/rabix/bindings/draft2/Draft2Bindings.java
+++ b/rabix-bindings-draft2/src/main/java/org/rabix/bindings/draft2/Draft2Bindings.java
@@ -26,6 +26,8 @@ import org.rabix.bindings.model.requirement.Requirement;
 import org.rabix.bindings.model.requirement.ResourceRequirement;
 import org.rabix.common.helper.ChecksumHelper.HashAlgorithm;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 public class Draft2Bindings implements Bindings {
 
   private final ProtocolType protocolType;
@@ -50,7 +52,7 @@ public class Draft2Bindings implements Bindings {
   }
   
   @Override
-  public String loadApp(String uri) throws BindingException {
+  public JsonNode loadApp(String uri) throws BindingException {
     return appProcessor.loadApp(uri);
   }
   

--- a/rabix-bindings-draft2/src/main/java/org/rabix/bindings/draft2/helper/Draft2JobHelper.java
+++ b/rabix-bindings-draft2/src/main/java/org/rabix/bindings/draft2/helper/Draft2JobHelper.java
@@ -10,14 +10,16 @@ import org.rabix.bindings.draft2.bean.Draft2JobApp;
 import org.rabix.bindings.draft2.bean.Draft2Resources;
 import org.rabix.bindings.draft2.resolver.Draft2DocumentResolver;
 import org.rabix.bindings.model.Job;
-import org.rabix.common.json.BeanSerializer;
+import org.rabix.common.helper.JSONHelper;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 public class Draft2JobHelper {
 
   @SuppressWarnings("unchecked")
   public static Draft2Job getDraft2Job(Job job) throws BindingException {
-    String resolvedAppStr = Draft2DocumentResolver.resolve(job.getApp());
-    Draft2JobApp app = BeanSerializer.deserialize(resolvedAppStr, Draft2JobApp.class);
+    JsonNode resolvedAppStr = Draft2DocumentResolver.resolve(job.getApp());
+    Draft2JobApp app = JSONHelper.readObject(resolvedAppStr, Draft2JobApp.class);
     
     Map<String, Object> nativeInputs = (Map<String, Object>) Draft2ValueTranslator.translateToSpecific(job.getInputs());
     Map<String, Object> nativeOutputs = (Map<String, Object>) Draft2ValueTranslator.translateToSpecific(job.getOutputs());

--- a/rabix-bindings-draft2/src/main/java/org/rabix/bindings/draft2/resolver/Draft2DocumentResolver.java
+++ b/rabix-bindings-draft2/src/main/java/org/rabix/bindings/draft2/resolver/Draft2DocumentResolver.java
@@ -12,8 +12,6 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
@@ -39,19 +37,13 @@ public class Draft2DocumentResolver {
   private static final String DEFAULT_ENCODING = "UTF-8";
   
   public static final String CWL_VERSION_KEY = "cwlVersion";
-
-  private static ConcurrentMap<String, String> cache = new ConcurrentHashMap<>(); 
   
   private static final Map<String, Map<String, JsonNode>> fragmentsCache = new HashMap<>();
 
   private static final Map<String, Map<String, Draft2DocumentResolverReference>> referenceCache = new HashMap<>();
   private static final Map<String, LinkedHashSet<Draft2DocumentResolverReplacement>> replacements = new HashMap<>();
   
-  public static String resolve(String appUrl) throws BindingException {
-    if (cache.containsKey(appUrl)) {
-      return cache.get(appUrl);
-    }
-    
+  public static JsonNode resolve(String appUrl) throws BindingException {
     String appUrlBase = appUrl;
     if (!URIHelper.isData(appUrl)) {
       appUrlBase = URIHelper.extractBase(appUrl);
@@ -95,12 +87,11 @@ public class Draft2DocumentResolver {
       }
     }
     
-    cache.put(appUrl, JSONHelper.writeObject(root));
 
     clearReplacements(appUrl);
     clearReferenceCache(appUrl);
     clearFragmentCache(appUrl);
-    return cache.get(appUrl);
+    return root;
   }
   
   private static JsonNode traverse(String appUrl, JsonNode root, File file, JsonNode parentNode, JsonNode currentNode) throws BindingException {

--- a/rabix-bindings-draft2/src/test/java/org/rabix/bindings/draft2/reference/Draft2ReferenceResolverTest.java
+++ b/rabix-bindings-draft2/src/test/java/org/rabix/bindings/draft2/reference/Draft2ReferenceResolverTest.java
@@ -21,7 +21,7 @@ public class Draft2ReferenceResolverTest {
     String fileURI = URIHelper.createURI(URIHelper.FILE_URI_SCHEME, filePath);
     
     JsonNode resolvedRoot = readJsonNode("count-lines1-wf-resolved.cwl.json");
-    Assert.assertEquals(Draft2DocumentResolver.resolve(fileURI), JSONHelper.writeObject(resolvedRoot));
+    Assert.assertEquals(Draft2DocumentResolver.resolve(fileURI), resolvedRoot);
   }
 
   @Test
@@ -30,7 +30,7 @@ public class Draft2ReferenceResolverTest {
     String fileURI = URIHelper.createURI(URIHelper.FILE_URI_SCHEME, filePath);
     
     JsonNode resolvedRoot = readJsonNode("regular-resolved.json");
-    Assert.assertEquals(Draft2DocumentResolver.resolve(fileURI), JSONHelper.writeObject(resolvedRoot));
+    Assert.assertEquals(Draft2DocumentResolver.resolve(fileURI), resolvedRoot);
   }
 
   @Test
@@ -39,7 +39,7 @@ public class Draft2ReferenceResolverTest {
     String fileURI = URIHelper.createURI(URIHelper.FILE_URI_SCHEME, filePath);
     
     JsonNode resolvedRoot = readJsonNode("regular-json-pointer-resolved.json");
-    Assert.assertEquals(Draft2DocumentResolver.resolve(fileURI), JSONHelper.writeObject(resolvedRoot));
+    Assert.assertEquals(Draft2DocumentResolver.resolve(fileURI), resolvedRoot);
   }
 
   @Test(expectedExceptions = { BindingException.class })

--- a/rabix-bindings-draft3/src/main/java/org/rabix/bindings/draft3/Draft3AppProcessor.java
+++ b/rabix-bindings-draft3/src/main/java/org/rabix/bindings/draft3/Draft3AppProcessor.java
@@ -11,18 +11,20 @@ import org.rabix.bindings.draft3.helper.Draft3SchemaHelper;
 import org.rabix.bindings.draft3.resolver.Draft3DocumentResolver;
 import org.rabix.bindings.model.Application;
 import org.rabix.bindings.model.Job;
-import org.rabix.common.json.BeanSerializer;
+import org.rabix.common.helper.JSONHelper;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 public class Draft3AppProcessor implements ProtocolAppProcessor {
 
   @Override
-  public String loadApp(String uri) throws BindingException {
+  public JsonNode loadApp(String uri) throws BindingException {
     return Draft3DocumentResolver.resolve(uri);
   }
   
   @Override
   public Application loadAppObject(String app) throws BindingException {
-    return BeanSerializer.deserialize(loadApp(app), Draft3JobApp.class);
+    return JSONHelper.readObject(loadApp(app), Draft3JobApp.class);
   }
 
   @Override

--- a/rabix-bindings-draft3/src/main/java/org/rabix/bindings/draft3/Draft3Bindings.java
+++ b/rabix-bindings-draft3/src/main/java/org/rabix/bindings/draft3/Draft3Bindings.java
@@ -26,6 +26,8 @@ import org.rabix.bindings.model.requirement.Requirement;
 import org.rabix.bindings.model.requirement.ResourceRequirement;
 import org.rabix.common.helper.ChecksumHelper.HashAlgorithm;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 public class Draft3Bindings implements Bindings {
 
   private final ProtocolType protocolType;
@@ -50,7 +52,7 @@ public class Draft3Bindings implements Bindings {
   }
   
   @Override
-  public String loadApp(String uri) throws BindingException {
+  public JsonNode loadApp(String uri) throws BindingException {
     return appProcessor.loadApp(uri);
   }
   

--- a/rabix-bindings-draft3/src/main/java/org/rabix/bindings/draft3/helper/Draft3JobHelper.java
+++ b/rabix-bindings-draft3/src/main/java/org/rabix/bindings/draft3/helper/Draft3JobHelper.java
@@ -11,14 +11,16 @@ import org.rabix.bindings.draft3.bean.Draft3Runtime;
 import org.rabix.bindings.draft3.expression.Draft3ExpressionException;
 import org.rabix.bindings.draft3.resolver.Draft3DocumentResolver;
 import org.rabix.bindings.model.Job;
-import org.rabix.common.json.BeanSerializer;
+import org.rabix.common.helper.JSONHelper;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 public class Draft3JobHelper {
 
   @SuppressWarnings("unchecked")
   public static Draft3Job getDraft3Job(Job job) throws BindingException {
-    String resolvedAppStr = Draft3DocumentResolver.resolve(job.getApp());
-    Draft3JobApp app = BeanSerializer.deserialize(resolvedAppStr, Draft3JobApp.class);
+    JsonNode resolvedApp = Draft3DocumentResolver.resolve(job.getApp());
+    Draft3JobApp app = JSONHelper.readObject(resolvedApp, Draft3JobApp.class);
     
     Map<String, Object> nativeInputs = (Map<String, Object>) Draft3ValueTranslator.translateToSpecific(job.getInputs());
     Map<String, Object> nativeOutputs = (Map<String, Object>) Draft3ValueTranslator.translateToSpecific(job.getOutputs());

--- a/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/SBAppProcessor.java
+++ b/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/SBAppProcessor.java
@@ -11,18 +11,20 @@ import org.rabix.bindings.sb.bean.SBJobAppType;
 import org.rabix.bindings.sb.helper.SBJobHelper;
 import org.rabix.bindings.sb.helper.SBSchemaHelper;
 import org.rabix.bindings.sb.resolver.SBDocumentResolver;
-import org.rabix.common.json.BeanSerializer;
+import org.rabix.common.helper.JSONHelper;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 public class SBAppProcessor implements ProtocolAppProcessor {
 
   @Override
-  public String loadApp(String uri) throws BindingException {
+  public JsonNode loadApp(String uri) throws BindingException {
     return SBDocumentResolver.resolve(uri);
   }
   
   @Override
   public Application loadAppObject(String app) throws BindingException {
-    return BeanSerializer.deserialize(loadApp(app), SBJobApp.class);
+    return JSONHelper.readObject(loadApp(app), SBJobApp.class);
   }
 
   @Override

--- a/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/SBBindings.java
+++ b/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/SBBindings.java
@@ -26,6 +26,8 @@ import org.rabix.bindings.model.requirement.ResourceRequirement;
 import org.rabix.bindings.sb.helper.SBSchemaHelper;
 import org.rabix.common.helper.ChecksumHelper.HashAlgorithm;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 public class SBBindings implements Bindings {
 
   private final ProtocolType protocolType;
@@ -50,7 +52,7 @@ public class SBBindings implements Bindings {
   }
   
   @Override
-  public String loadApp(String uri) throws BindingException {
+  public JsonNode loadApp(String uri) throws BindingException {
     return appProcessor.loadApp(uri);
   }
   

--- a/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/helper/SBJobHelper.java
+++ b/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/helper/SBJobHelper.java
@@ -10,14 +10,16 @@ import org.rabix.bindings.sb.bean.SBJob;
 import org.rabix.bindings.sb.bean.SBJobApp;
 import org.rabix.bindings.sb.bean.SBResources;
 import org.rabix.bindings.sb.resolver.SBDocumentResolver;
-import org.rabix.common.json.BeanSerializer;
+import org.rabix.common.helper.JSONHelper;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 public class SBJobHelper {
 
   @SuppressWarnings("unchecked")
   public static SBJob getSBJob(Job job) throws BindingException {
-    String resolvedAppStr = SBDocumentResolver.resolve(job.getApp());
-    SBJobApp app = BeanSerializer.deserialize(resolvedAppStr, SBJobApp.class);
+    JsonNode resolvedApp = SBDocumentResolver.resolve(job.getApp());
+    SBJobApp app = JSONHelper.readObject(resolvedApp, SBJobApp.class);
     
     Map<String, Object> nativeInputs = (Map<String, Object>) SBValueTranslator.translateToSpecific(job.getInputs());
     Map<String, Object> nativeOutputs = (Map<String, Object>) SBValueTranslator.translateToSpecific(job.getOutputs());

--- a/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/resolver/SBDocumentResolver.java
+++ b/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/resolver/SBDocumentResolver.java
@@ -12,8 +12,6 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
@@ -25,7 +23,6 @@ import org.rabix.common.helper.JSONHelper;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.base.Preconditions;
 
 public class SBDocumentResolver {
@@ -37,19 +34,13 @@ public class SBDocumentResolver {
   public static final String DOCUMENT_FRAGMENT_SEPARATOR = "#";
   
   private static final String DEFAULT_ENCODING = "UTF-8";
-
-  private static ConcurrentMap<String, String> cache = new ConcurrentHashMap<>(); 
   
   private static final Map<String, Map<String, JsonNode>> fragmentsCache = new HashMap<>();
 
   private static final Map<String, Map<String, SBDocumentResolverReference>> referenceCache = new HashMap<>();
   private static final Map<String, LinkedHashSet<SBDocumentResolverReplacement>> replacements = new HashMap<>();
   
-  public static String resolve(String appUrl) throws BindingException {
-    if (cache.containsKey(appUrl)) {
-      return cache.get(appUrl);
-    }
-    
+  public static JsonNode resolve(String appUrl) throws BindingException {
     String appUrlBase = appUrl;
     if (!URIHelper.isData(appUrl)) {
       appUrlBase = URIHelper.extractBase(appUrl);
@@ -95,12 +86,11 @@ public class SBDocumentResolver {
       clearFragmentCache(appUrl);
       throw new BindingException("Document version is not sbg:draft-2");
     }
-    cache.put(appUrl, JSONHelper.writeObject(root));
     
     clearReplacements(appUrl);
     clearReferenceCache(appUrl);
     clearFragmentCache(appUrl);
-    return cache.get(appUrl);
+    return root;
   }
   
   private static JsonNode traverse(String appUrl, JsonNode root, File file, JsonNode parentNode, JsonNode currentNode) throws BindingException {

--- a/rabix-bindings/src/main/java/org/rabix/bindings/Bindings.java
+++ b/rabix-bindings/src/main/java/org/rabix/bindings/Bindings.java
@@ -14,6 +14,8 @@ import org.rabix.bindings.model.requirement.Requirement;
 import org.rabix.bindings.model.requirement.ResourceRequirement;
 import org.rabix.common.helper.ChecksumHelper.HashAlgorithm;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 public interface Bindings {
 
   /**
@@ -23,7 +25,7 @@ public interface Bindings {
    * @return            Application as string
    * @throws BindingException
    */
-  String loadApp(String appURI) throws BindingException;
+  JsonNode loadApp(String appURI) throws BindingException;
   
   /**
    * Loads application object from URL

--- a/rabix-bindings/src/main/java/org/rabix/bindings/ProtocolAppProcessor.java
+++ b/rabix-bindings/src/main/java/org/rabix/bindings/ProtocolAppProcessor.java
@@ -3,13 +3,15 @@ package org.rabix.bindings;
 import org.rabix.bindings.model.Application;
 import org.rabix.bindings.model.Job;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 public interface ProtocolAppProcessor {
 
   void validate(Job job) throws BindingException;
   
   boolean isSelfExecutable(Job job) throws BindingException;
 
-  String loadApp(String uri) throws BindingException;
+  JsonNode loadApp(String uri) throws BindingException;
   
   Application loadAppObject(String app) throws BindingException;
 


### PR DESCRIPTION
Removed caches that were growing infinitely without being cleared from document resolvers and removed unneeded serializations to string and back to node.