### PR TITLE
A change to the empty list scatter handling

### DIFF
--- a/rabix-engine/src/main/java/org/rabix/engine/processor/handler/impl/OutputEventHandler.java
+++ b/rabix-engine/src/main/java/org/rabix/engine/processor/handler/impl/OutputEventHandler.java
@@ -74,7 +74,7 @@ public class OutputEventHandler implements EventHandler<OutputUpdateEvent> {
     }
     VariableRecord sourceVariable = variableService.find(event.getJobId(), event.getPortId(), LinkPortType.OUTPUT, event.getContextId());
     jobRecordService.decrementPortCounter(sourceJob, event.getPortId(), LinkPortType.OUTPUT);
-    variableService.addValue(sourceVariable, event.getValue(), event.getPosition(), (sourceJob.isScatterWrapper() || event.isFromScatter()) && !sourceJob.getScatterStrategy().isEmptyListDetected());
+    variableService.addValue(sourceVariable, event.getValue(), event.getPosition(), (sourceJob.isScatterWrapper() || event.isFromScatter()) && (sourceJob.getScatterStrategy() == null || !sourceJob.getScatterStrategy().isEmptyListDetected()));
     variableService.update(sourceVariable); // TODO wha?
     jobRecordService.update(sourceJob);
     

--- a/rabix-engine/src/main/java/org/rabix/engine/processor/handler/impl/OutputEventHandler.java
+++ b/rabix-engine/src/main/java/org/rabix/engine/processor/handler/impl/OutputEventHandler.java
@@ -74,7 +74,7 @@ public class OutputEventHandler implements EventHandler<OutputUpdateEvent> {
     }
     VariableRecord sourceVariable = variableService.find(event.getJobId(), event.getPortId(), LinkPortType.OUTPUT, event.getContextId());
     jobRecordService.decrementPortCounter(sourceJob, event.getPortId(), LinkPortType.OUTPUT);
-    variableService.addValue(sourceVariable, event.getValue(), event.getPosition(), sourceJob.isScatterWrapper() || event.isFromScatter());
+    variableService.addValue(sourceVariable, event.getValue(), event.getPosition(), (sourceJob.isScatterWrapper() || event.isFromScatter()) && !sourceJob.getScatterStrategy().isEmptyListDetected());
     variableService.update(sourceVariable); // TODO wha?
     jobRecordService.update(sourceJob);
     

--- a/rabix-engine/src/main/java/org/rabix/engine/processor/handler/impl/OutputEventHandler.java
+++ b/rabix-engine/src/main/java/org/rabix/engine/processor/handler/impl/OutputEventHandler.java
@@ -74,7 +74,7 @@ public class OutputEventHandler implements EventHandler<OutputUpdateEvent> {
     }
     VariableRecord sourceVariable = variableService.find(event.getJobId(), event.getPortId(), LinkPortType.OUTPUT, event.getContextId());
     jobRecordService.decrementPortCounter(sourceJob, event.getPortId(), LinkPortType.OUTPUT);
-    variableService.addValue(sourceVariable, event.getValue(), event.getPosition(), (sourceJob.isScatterWrapper() || event.isFromScatter()) && (sourceJob.getScatterStrategy() == null || !sourceJob.getScatterStrategy().isEmptyListDetected()));
+    variableService.addValue(sourceVariable, event.getValue(), event.getPosition(), event.isFromScatter());
     variableService.update(sourceVariable); // TODO wha?
     jobRecordService.update(sourceJob);
     

--- a/rabix-engine/src/main/java/org/rabix/engine/processor/handler/impl/ScatterHandler.java
+++ b/rabix-engine/src/main/java/org/rabix/engine/processor/handler/impl/ScatterHandler.java
@@ -80,8 +80,12 @@ public class ScatterHandler {
         throw new EventHandlerException(e);
       }
     }
+    
+    if(value instanceof List<?> && ((List<?>)value).isEmpty()){
+      scatterStrategy.setEmptyListDetected();
+    }
 
-    if (isLookAhead) {
+    if (isLookAhead && !scatterStrategy.isEmptyListDetected()) {
       int numberOfScattered = getNumberOfScattered(job, numberOfScatteredFromEvent);
       createScatteredJobs(job, event, portId, value, node, numberOfScattered, position);
       return;
@@ -110,9 +114,7 @@ public class ScatterHandler {
       values = (List<Object>) value;
     }
     
-    if (values.size() == 0) {
-      scatterStrategy.setEmptyListDetected();
-    } else {
+    if (!scatterStrategy.isEmptyListDetected()) {
       for (int i = 0; i < values.size(); i++) {
         createScatteredJobs(job, event, portId, values.get(i), node, values.size(), usePositionFromEvent ? position : i + 1);
       }


### PR DESCRIPTION
Stops the wrapping of empty lists and premature exit from the scatter port method if empty list is detected.

Relates to https://github.com/rabix/bunny/issues/246