### PR TITLE
Removed a transaction inside a transaction

### DIFF
--- a/rabix-engine/src/main/java/org/rabix/engine/service/impl/BootstrapServiceImpl.java
+++ b/rabix-engine/src/main/java/org/rabix/engine/service/impl/BootstrapServiceImpl.java
@@ -45,13 +45,10 @@ public class BootstrapServiceImpl implements BootstrapService {
   @Override
   public void start() throws BootstrapServiceException {
     try {
-      transactionHelper.doInTransaction(() -> {
         eventProcessor.start();
         backendService.scanEmbedded();
         schedulerService.start();
         storeCleanupService.start();
-        return null;
-      });
     } catch (Exception e) {
       throw new BootstrapServiceException(e);
     }


### PR DESCRIPTION
Crashes when using postgres because backendService.scanEmbedded() creates another transaction to save backend to db