### PR TITLE
Fixes #274, commented javascript lines caused error in resolver.

### DIFF
--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/expression/CWLExpressionResolver.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/expression/CWLExpressionResolver.java
@@ -176,6 +176,7 @@ public class CWLExpressionResolver {
   }
 
   private static int[] scanJavascriptExpression(String expression) throws CWLExpressionException {
+
     int DEFAULT = 0;
     int DOLLAR = 1;
     int PAREN = 2;
@@ -183,6 +184,8 @@ public class CWLExpressionResolver {
     int SINGLE_QUOTE = 4;
     int DOUBLE_QUOTE = 5;
     int BACKSLASH = 6;
+    int QUOTE_FIRST = 7;
+    int QUOTE_SECOND = 8;
 
     int i = 0;
     Stack<Integer> stack = new Stack<>();
@@ -196,56 +199,92 @@ public class CWLExpressionResolver {
       if (state == DEFAULT) {
         if (c == '$') {
           stack.push(DOLLAR);
-        } else if (c == '\\') {
+        }
+        else if (c == '\\') {
           stack.push(BACKSLASH);
         }
-      } else if (state == BACKSLASH) {
+      }
+      else if (state == BACKSLASH) {
         stack.pop();
-      } else if (state == DOLLAR) {
+      }
+      else if (state == DOLLAR) {
         if (c == '(') {
           start = i - 1;
           stack.push(PAREN);
-        } else if (c == '{') {
+        }
+        else if (c == '{') {
           start = i - 1;
           stack.push(BRACE);
         }
-      } else if (state == PAREN) {
+      }
+      else if (state == PAREN) {
         if (c == '(') {
           stack.push(PAREN);
-        } else if (c == ')') {
+        }
+        else if (c == ')') {
           stack.pop();
           if (stack.peek() == DOLLAR) {
             return new int[] { start, i + 1 };
           }
-        } else if (c == '\'') {
+        }
+        else if (c == '\'') {
           stack.push(SINGLE_QUOTE);
-        } else if (c == '"') {
+        }
+        else if (c == '"') {
           stack.push(DOUBLE_QUOTE);
         }
-      } else if (state == BRACE) {
+        else if (c == '/') {
+          stack.push(QUOTE_FIRST);
+        }
+      }
+      else if (state == BRACE) {
         if (c == '{') {
           stack.push(BRACE);
-        } else if (c == '}') {
+        }
+        else if (c == '}') {
           stack.pop();
           if (stack.peek() == DOLLAR) {
             return new int[] { start, i + 1 };
           }
-        } else if (c == '\'') {
+        }
+        else if (c == '\'') {
           stack.push(SINGLE_QUOTE);
-        } else if (c == '"') {
+        }
+        else if (c == '"') {
           stack.push(DOUBLE_QUOTE);
         }
-      } else if (state == SINGLE_QUOTE) {
+        else if (c == '/') {
+          stack.push(QUOTE_FIRST);
+        }
+      }
+      else if (state == SINGLE_QUOTE) {
         if (c == '\'') {
           stack.pop();
-        } else if (c == '\\') {
+        }
+        else if (c == '\\') {
           stack.push(BACKSLASH);
         }
-      } else if (state == DOUBLE_QUOTE) {
+      }
+      else if (state == DOUBLE_QUOTE) {
         if (c == '\"') {
           stack.pop();
-        } else if (c == '\\') {
+        }
+        else if (c == '\\') {
           stack.push(BACKSLASH);
+        }
+      }
+      else if (state == QUOTE_FIRST) {
+        if (c == '/') {
+          stack.pop();
+          stack.push(QUOTE_SECOND);
+        }
+        else {
+          stack.pop();
+        }
+      }
+      else if (state == QUOTE_SECOND) {
+        if (c == '\n') {
+          stack.pop();
         }
       }
       i++;


### PR DESCRIPTION
Resolver didn't check whether the processed line is commented out or not. This caused a problem when a comment like following occurred in the javascript code
```
// This should'nt affect code
```
Resolver thinks there is a quotation started in ```should'nt``` but it has no matching end.

Edit: Forgot to add the mention to the issue.