### PR TITLE
handling empty strings when quoting

### DIFF
--- a/rabix-common/src/main/java/org/rabix/common/helper/EncodingHelper.java
+++ b/rabix-common/src/main/java/org/rabix/common/helper/EncodingHelper.java
@@ -22,7 +22,7 @@ public class EncodingHelper {
   }
   
   public static String shellQuote(String argument) {
-    if (!NEEDS_QUOTING_PATTERN.matcher(argument).find()) {
+    if (!NEEDS_QUOTING_PATTERN.matcher(argument).find() && !argument.equals("")) {
       return argument;
     }
     return "'" + argument.replace("'", "'\\''") + "'";


### PR DESCRIPTION
@AleksandarPetrovicSBG , @simonovic86 cwltool puts empty quotation marks when provided empty string, as we concluded is the most meaningful solution, so with this fix, bunny has the same behavior.