### PR TITLE
Task/schema processing

### DIFF
--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/CWLProcessor.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/CWLProcessor.java
@@ -473,7 +473,6 @@ public class CWLProcessor implements ProtocolProcessor {
           secondaryFilePath = suffix;
         }
         File secondaryFile = new File(secondaryFilePath);
-        if (secondaryFile.exists()) {
           if (secondaryFile.isDirectory()) {
             CWLFileValueHelper.setDirType(secondaryFileMap);
           } else {
@@ -482,10 +481,9 @@ public class CWLProcessor implements ProtocolProcessor {
           CWLFileValueHelper.setPath(secondaryFile.getAbsolutePath(), secondaryFileMap);
           CWLFileValueHelper.setSize(secondaryFile.length(), secondaryFileMap);
           CWLFileValueHelper.setName(secondaryFile.getName(), secondaryFileMap);
-          if (hashAlgorithm != null && !secondaryFile.isDirectory()) {
+          if (hashAlgorithm != null && secondaryFile.exists() && !secondaryFile.isDirectory()) {
             CWLFileValueHelper.setChecksum(secondaryFile, secondaryFileMap, hashAlgorithm);
           }
-        }
       } else if (expr instanceof Map) {
         secondaryFileMap = (Map<String, Object>) expr;
         postprocessCreatedResults(secondaryFileMap, hashAlgorithm, workingDir);

--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/bean/CWLInputPort.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/bean/CWLInputPort.java
@@ -2,6 +2,7 @@ package org.rabix.bindings.cwl.bean;
 
 import org.rabix.bindings.cwl.helper.CWLSchemaHelper;
 import org.rabix.bindings.model.ApplicationPort;
+import org.rabix.bindings.model.StageInput;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -76,6 +77,12 @@ public class CWLInputPort extends ApplicationPort {
   @Override
   public boolean isRequired() {
     return CWLSchemaHelper.isRequired(schema);
+  }
+
+  @Override
+  @JsonIgnore
+  public Object getBinding() {
+    return inputBinding;
   }
 
 }

--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/bean/CWLOutputPort.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/bean/CWLOutputPort.java
@@ -61,4 +61,9 @@ public class CWLOutputPort extends ApplicationPort {
     return "OutputPort [outputBinding=" + outputBinding + ", id=" + getId() + ", schema=" + getSchema() + ", scatter=" + getScatter() + ", source=" + source + "]";
   }
 
+  @JsonIgnore
+  @Override
+  public Object getBinding() {
+    return outputBinding;
+  }
 }

--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/processor/CWLPortProcessorCallback.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/processor/CWLPortProcessorCallback.java
@@ -4,6 +4,6 @@ import org.rabix.bindings.model.ApplicationPort;
 
 public interface CWLPortProcessorCallback {
 
-  CWLPortProcessorResult process(Object value, ApplicationPort port) throws Exception;
+  CWLPortProcessorResult process(Object value, String id, Object schema, Object binding, ApplicationPort parentPort) throws Exception;
   
 }

--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/processor/callback/CWLFileBasenameCheckProcessorCallback.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/processor/callback/CWLFileBasenameCheckProcessorCallback.java
@@ -9,7 +9,7 @@ import org.rabix.bindings.model.ApplicationPort;
 public class CWLFileBasenameCheckProcessorCallback implements CWLPortProcessorCallback {
 
   @Override
-  public CWLPortProcessorResult process(Object value, ApplicationPort port) throws Exception {
+  public CWLPortProcessorResult process(Object value, String id, Object schema, Object binding, ApplicationPort parentPort) throws Exception {
     if (CWLSchemaHelper.isFileFromValue(value) || CWLSchemaHelper.isDirectoryFromValue(value)) {
       String basename = CWLFileValueHelper.getName(value);
       String path = CWLFileValueHelper.getPath(value);

--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/processor/callback/CWLFileLiteralProcessorCallback.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/processor/callback/CWLFileLiteralProcessorCallback.java
@@ -21,13 +21,13 @@ public class CWLFileLiteralProcessorCallback implements CWLPortProcessorCallback
   }
   
   @Override
-  public CWLPortProcessorResult process(Object value, ApplicationPort port) throws Exception {
+  public CWLPortProcessorResult process(Object value, String id, Object schema, Object binding, ApplicationPort parentPort) throws Exception {
     if (CWLSchemaHelper.isFileFromValue(value)) {
       String path = CWLFileValueHelper.getPath(value);
       if (path == null) {
         String contents = CWLFileValueHelper.getContents(value);
         if (StringUtils.isEmpty(contents)) {
-          throw new CWLPortProcessorException("Cannot process file literal for port " + port.getId());
+          throw new CWLPortProcessorException("Cannot process file literal for port " + id);
         }
         String name = CWLFileValueHelper.getName(value);
         if (StringUtils.isEmpty(name)) {

--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/processor/callback/CWLFileLocationToPathProcessorCallback.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/processor/callback/CWLFileLocationToPathProcessorCallback.java
@@ -13,7 +13,7 @@ public class CWLFileLocationToPathProcessorCallback implements CWLPortProcessorC
   }
 
   @Override
-  public CWLPortProcessorResult process(Object value, ApplicationPort port) throws CWLPortProcessorException {
+  public CWLPortProcessorResult process(Object value, String id, Object schema, Object binding, ApplicationPort parentPort) throws CWLPortProcessorException {
     if (value == null) {
       return new CWLPortProcessorResult(value, false);
     }

--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/processor/callback/CWLFilePathMapProcessorCallback.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/processor/callback/CWLFilePathMapProcessorCallback.java
@@ -26,7 +26,7 @@ public class CWLFilePathMapProcessorCallback implements CWLPortProcessorCallback
   }
 
   @Override
-  public CWLPortProcessorResult process(Object value, ApplicationPort port) throws CWLPortProcessorException {
+  public CWLPortProcessorResult process(Object value, String id, Object schema, Object binding, ApplicationPort parentPort) throws CWLPortProcessorException {
     if (value == null) {
       return new CWLPortProcessorResult(value, false);
     }

--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/processor/callback/CWLFilePropertiesProcessorCallback.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/processor/callback/CWLFilePropertiesProcessorCallback.java
@@ -20,7 +20,7 @@ import org.rabix.common.helper.CloneHelper;
 public class CWLFilePropertiesProcessorCallback implements CWLPortProcessorCallback {
 
   @Override
-  public CWLPortProcessorResult process(Object value, ApplicationPort port) throws Exception {
+  public CWLPortProcessorResult process(Object value, String id, Object schema, Object binding, ApplicationPort parentPort) throws Exception {
     if (CWLSchemaHelper.isFileFromValue(value) || CWLSchemaHelper.isDirectoryFromValue(value)) {
       Object clonedValue = CloneHelper.deepCopy(value);
 

--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/processor/callback/CWLFileValueProcessorCallback.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/processor/callback/CWLFileValueProcessorCallback.java
@@ -25,8 +25,8 @@ public class CWLFileValueProcessorCallback implements CWLPortProcessorCallback {
   }
   
   @Override
-  public CWLPortProcessorResult process(Object value, ApplicationPort port) throws Exception {
-    if ((CWLSchemaHelper.isFileFromValue(value) || CWLSchemaHelper.isDirectoryFromValue(value)) && !skip(port.getId())) {
+  public CWLPortProcessorResult process(Object value, String id, Object schema, Object binding, ApplicationPort parentPort) throws Exception {
+    if ((CWLSchemaHelper.isFileFromValue(value) || CWLSchemaHelper.isDirectoryFromValue(value)) && !skip(id)) {
       FileValue fileValue = null;
       if (CWLSchemaHelper.isFileFromValue(value)) {
         fileValue = CWLFileValueHelper.createFileValue(value);

--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/processor/callback/CWLFileValueUpdateProcessorCallback.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/processor/callback/CWLFileValueUpdateProcessorCallback.java
@@ -24,7 +24,7 @@ public class CWLFileValueUpdateProcessorCallback implements CWLPortProcessorCall
   }
 
   @Override
-  public CWLPortProcessorResult process(Object value, ApplicationPort port) throws Exception {
+  public CWLPortProcessorResult process(Object value, String id, Object schema, Object binding, ApplicationPort parentPort) throws Exception {
     if (CWLSchemaHelper.isFileFromValue(value) || CWLSchemaHelper.isDirectoryFromValue(value)) {
       Object clonedValue = CloneHelper.deepCopy(value);
 

--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/processor/callback/CWLInputSecondaryFilesProcessor.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/processor/callback/CWLInputSecondaryFilesProcessor.java
@@ -13,6 +13,7 @@ import org.rabix.bindings.cwl.helper.CWLSchemaHelper;
 import org.rabix.bindings.cwl.processor.CWLPortProcessorCallback;
 import org.rabix.bindings.cwl.processor.CWLPortProcessorResult;
 import org.rabix.bindings.model.ApplicationPort;
+import org.rabix.bindings.model.FileValue;
 import org.rabix.common.helper.ChecksumHelper.HashAlgorithm;
 import org.rabix.common.helper.CloneHelper;
 
@@ -27,23 +28,30 @@ public class CWLInputSecondaryFilesProcessor implements CWLPortProcessorCallback
     this.workingDir = workingDir;
     this.hashAlgorithm = hashAlgorithm;
   }
-
+  
+  private boolean isFile(Object value){
+    return CWLSchemaHelper.isFileFromValue(value) || CWLSchemaHelper.isDirectoryFromValue(value) || FileValue.isFileValue(value) ;
+  }
+  
   @Override
   @SuppressWarnings("unchecked")
-  public CWLPortProcessorResult process(Object value, ApplicationPort port) throws Exception {
-    if ((CWLSchemaHelper.isFileFromValue(value) || CWLSchemaHelper.isDirectoryFromValue(value)) && port instanceof CWLInputPort) {
+  public CWLPortProcessorResult process(Object value, String id, Object schema, Object binding, ApplicationPort parentPort) throws Exception {
+    if (isFile(value) && parentPort instanceof CWLInputPort) {
       if (!CollectionUtils.isEmpty(CWLFileValueHelper.getSecondaryFiles(value))) {
         return new CWLPortProcessorResult(value, false); 
       }
-      Object secondaryFilesObj = ((CWLInputPort) port).getSecondaryFiles();
-      if (secondaryFilesObj == null) {
+      
+      Object secondaryFiles = CWLFileValueHelper.getSecondaryFiles(binding);
+      if(secondaryFiles == null)
+        secondaryFiles = ((CWLInputPort) parentPort).getSecondaryFiles();
+      if (secondaryFiles == null) {
         return new CWLPortProcessorResult(value, false);
       }
 
       Map<String, Object> clonedValue = (Map<String, Object>) CloneHelper.deepCopy(value);
-      List<Map<String, Object>> secondaryFiles = CWLProcessor.getSecondaryFiles(job, hashAlgorithm, clonedValue,  CWLFileValueHelper.getLocation(clonedValue), secondaryFilesObj, workingDir);
+      List<Map<String, Object>> outs = CWLProcessor.getSecondaryFiles(job, hashAlgorithm, clonedValue,  CWLFileValueHelper.getPath(clonedValue), secondaryFiles, workingDir);
       if (secondaryFiles != null) {
-        CWLFileValueHelper.setSecondaryFiles(secondaryFiles, clonedValue);
+        CWLFileValueHelper.setSecondaryFiles(outs, clonedValue);
         return new CWLPortProcessorResult(clonedValue, true);
       }
     }

--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/processor/callback/CWLLoadContentsPortProcessorCallback.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/processor/callback/CWLLoadContentsPortProcessorCallback.java
@@ -12,16 +12,15 @@ import org.rabix.common.helper.CloneHelper;
 public class CWLLoadContentsPortProcessorCallback implements CWLPortProcessorCallback {
 
   @Override
-  public CWLPortProcessorResult process(Object value, ApplicationPort port) throws Exception {
-    if ((CWLSchemaHelper.isFileFromValue(value) || CWLSchemaHelper.isDirectoryFromValue(value)) && port instanceof CWLInputPort) {
+  public CWLPortProcessorResult process(Object value, String id, Object schema, Object binding, ApplicationPort parentPort) throws Exception {
+    if ((CWLSchemaHelper.isFileFromValue(value) || CWLSchemaHelper.isDirectoryFromValue(value)) && parentPort instanceof CWLInputPort) {
       Object clonedValue = CloneHelper.deepCopy(value);
       
-      Object inputBinding = ((CWLInputPort) port).getInputBinding();
-      if (inputBinding == null) {
+      if (binding == null) {
         return new CWLPortProcessorResult(clonedValue, true);
       }
 
-      boolean loadContents = CWLBindingHelper.loadContents(inputBinding);
+      boolean loadContents = CWLBindingHelper.loadContents(binding);
       if (loadContents) {
         CWLFileValueHelper.setContents(clonedValue);
         return new CWLPortProcessorResult(clonedValue, true);

--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/processor/callback/CWLStageInputProcessorCallback.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/processor/callback/CWLStageInputProcessorCallback.java
@@ -17,7 +17,7 @@ import org.rabix.bindings.cwl.helper.CWLSchemaHelper;
 import org.rabix.bindings.cwl.processor.CWLPortProcessorCallback;
 import org.rabix.bindings.cwl.processor.CWLPortProcessorResult;
 import org.rabix.bindings.model.ApplicationPort;
-import org.rabix.bindings.model.ApplicationPort.StageInput;
+import org.rabix.bindings.model.StageInput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,11 +32,11 @@ public class CWLStageInputProcessorCallback implements CWLPortProcessorCallback 
   }
 
   @Override
-  public CWLPortProcessorResult process(Object value, ApplicationPort port) throws Exception {
-    if (!(port instanceof CWLInputPort)) {
+  public CWLPortProcessorResult process(Object value, String id, Object schema, Object binding, ApplicationPort parentPort) throws Exception {
+    if (!(parentPort instanceof CWLInputPort)) {
       throw new RuntimeException("Inputs only can be staged!");
     }
-    CWLInputPort inputPort = (CWLInputPort) port;
+    CWLInputPort inputPort = (CWLInputPort) parentPort;
     StageInput stageInput = inputPort.getStageInput();
     if (stageInput == null) {
       return new CWLPortProcessorResult(value, true);

--- a/rabix-bindings-draft2/src/main/java/org/rabix/bindings/draft2/bean/Draft2InputPort.java
+++ b/rabix-bindings-draft2/src/main/java/org/rabix/bindings/draft2/bean/Draft2InputPort.java
@@ -2,6 +2,7 @@ package org.rabix.bindings.draft2.bean;
 
 import org.rabix.bindings.draft2.helper.Draft2SchemaHelper;
 import org.rabix.bindings.model.ApplicationPort;
+import org.rabix.bindings.model.StageInput;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -56,5 +57,10 @@ public class Draft2InputPort extends ApplicationPort {
   public boolean isRequired() {
     return Draft2SchemaHelper.isRequired(schema);
   }
-
+  
+  @JsonIgnore
+  @Override
+  public Object getBinding() {
+   return inputBinding;
+  }
 }

--- a/rabix-bindings-draft2/src/main/java/org/rabix/bindings/draft2/bean/Draft2OutputPort.java
+++ b/rabix-bindings-draft2/src/main/java/org/rabix/bindings/draft2/bean/Draft2OutputPort.java
@@ -53,4 +53,10 @@ public class Draft2OutputPort extends ApplicationPort {
   protected void readDataType() {
     Draft2SchemaHelper.readDataType(schema);
   }
+  
+  @JsonIgnore
+  @Override
+  public Object getBinding() {
+    return outputBinding;
+  }
 }

--- a/rabix-bindings-draft2/src/main/java/org/rabix/bindings/draft2/processor/callback/Draft2StageInputProcessorCallback.java
+++ b/rabix-bindings-draft2/src/main/java/org/rabix/bindings/draft2/processor/callback/Draft2StageInputProcessorCallback.java
@@ -17,7 +17,7 @@ import org.rabix.bindings.draft2.helper.Draft2SchemaHelper;
 import org.rabix.bindings.draft2.processor.Draft2PortProcessorCallback;
 import org.rabix.bindings.draft2.processor.Draft2PortProcessorResult;
 import org.rabix.bindings.model.ApplicationPort;
-import org.rabix.bindings.model.ApplicationPort.StageInput;
+import org.rabix.bindings.model.StageInput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/rabix-bindings-draft3/src/main/java/org/rabix/bindings/draft3/bean/Draft3InputPort.java
+++ b/rabix-bindings-draft3/src/main/java/org/rabix/bindings/draft3/bean/Draft3InputPort.java
@@ -2,6 +2,7 @@ package org.rabix.bindings.draft3.bean;
 
 import org.rabix.bindings.draft3.helper.Draft3SchemaHelper;
 import org.rabix.bindings.model.ApplicationPort;
+import org.rabix.bindings.model.StageInput;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -72,5 +73,9 @@ public class Draft3InputPort extends ApplicationPort {
     return Draft3SchemaHelper.isRequired(schema);
   }
 
-  
+  @JsonIgnore
+  @Override
+  public Object getBinding() {
+    return inputBinding;
+  }
 }

--- a/rabix-bindings-draft3/src/main/java/org/rabix/bindings/draft3/bean/Draft3OutputPort.java
+++ b/rabix-bindings-draft3/src/main/java/org/rabix/bindings/draft3/bean/Draft3OutputPort.java
@@ -61,5 +61,10 @@ public class Draft3OutputPort extends ApplicationPort {
     return "OutputPort [outputBinding=" + outputBinding + ", id=" + getId() + ", schema=" + getSchema() + ", scatter="
         + getScatter() + ", source=" + source + "]";
   }
+  @JsonIgnore
+  @Override
+  public Object getBinding() {
+    return outputBinding;
+  }
 
 }

--- a/rabix-bindings-draft3/src/main/java/org/rabix/bindings/draft3/processor/callback/Draft3StageInputProcessorCallback.java
+++ b/rabix-bindings-draft3/src/main/java/org/rabix/bindings/draft3/processor/callback/Draft3StageInputProcessorCallback.java
@@ -17,7 +17,7 @@ import org.rabix.bindings.draft3.helper.Draft3SchemaHelper;
 import org.rabix.bindings.draft3.processor.Draft3PortProcessorCallback;
 import org.rabix.bindings.draft3.processor.Draft3PortProcessorResult;
 import org.rabix.bindings.model.ApplicationPort;
-import org.rabix.bindings.model.ApplicationPort.StageInput;
+import org.rabix.bindings.model.StageInput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/SBProcessor.java
+++ b/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/SBProcessor.java
@@ -374,17 +374,15 @@ public class SBProcessor implements ProtocolProcessor {
         secondaryFilePath += suffix.startsWith(".") ? suffix : "." + suffix;
       }
       File secondaryFile = new File(secondaryFilePath);
-      if (secondaryFile.exists()) {
         Map<String, Object> secondaryFileMap = new HashMap<>();
         SBFileValueHelper.setFileType(secondaryFileMap);
         SBFileValueHelper.setPath(secondaryFile.getAbsolutePath(), secondaryFileMap);
         SBFileValueHelper.setSize(secondaryFile.length(), secondaryFileMap);
         SBFileValueHelper.setName(secondaryFile.getName(), secondaryFileMap);
-        if (hashAlgorithm != null) {
+        if (hashAlgorithm != null && secondaryFile.exists()) {
           SBFileValueHelper.setChecksum(secondaryFile, secondaryFileMap, hashAlgorithm);
         }
         secondaryFileMaps.add(secondaryFileMap);
-      }
     }
     return secondaryFileMaps;
   }

--- a/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/bean/SBInputPort.java
+++ b/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/bean/SBInputPort.java
@@ -1,6 +1,7 @@
 package org.rabix.bindings.sb.bean;
 
 import org.rabix.bindings.model.ApplicationPort;
+import org.rabix.bindings.model.StageInput;
 import org.rabix.bindings.sb.helper.SBSchemaHelper;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -57,4 +58,9 @@ public class SBInputPort extends ApplicationPort {
     return SBSchemaHelper.isRequired(schema);
   }
 
+  @JsonIgnore
+  @Override
+  public Object getBinding() {
+    return inputBinding;
+  }
 }

--- a/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/bean/SBOutputPort.java
+++ b/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/bean/SBOutputPort.java
@@ -53,4 +53,10 @@ public class SBOutputPort extends ApplicationPort {
   protected void readDataType() {
     dataType = SBSchemaHelper.readDataType(schema);
   }
+
+  @JsonIgnore
+  @Override
+  public Object getBinding() {
+    return outputBinding;
+  }
 }

--- a/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/processor/SBPortProcessorCallback.java
+++ b/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/processor/SBPortProcessorCallback.java
@@ -4,6 +4,6 @@ import org.rabix.bindings.model.ApplicationPort;
 
 public interface SBPortProcessorCallback {
 
-  SBPortProcessorResult process(Object value, ApplicationPort port) throws Exception;
+  SBPortProcessorResult process(Object value, String id, Object schema, Object binding, ApplicationPort parentPort) throws Exception;
   
 }

--- a/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/processor/callback/SBFilePathMapProcessorCallback.java
+++ b/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/processor/callback/SBFilePathMapProcessorCallback.java
@@ -24,7 +24,7 @@ public class SBFilePathMapProcessorCallback implements SBPortProcessorCallback {
 
   @Override
   @SuppressWarnings("unchecked")
-  public SBPortProcessorResult process(Object value, ApplicationPort port) throws SBPortProcessorException {
+  public SBPortProcessorResult process(Object value, String id, Object schema, Object binding, ApplicationPort parentPort) throws SBPortProcessorException {
     if (value == null) {
       return new SBPortProcessorResult(value, false);
     }

--- a/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/processor/callback/SBFileSizeProcessorCallback.java
+++ b/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/processor/callback/SBFileSizeProcessorCallback.java
@@ -14,7 +14,7 @@ import org.rabix.common.helper.CloneHelper;
 public class SBFileSizeProcessorCallback implements SBPortProcessorCallback {
 
   @Override
-  public SBPortProcessorResult process(Object value, ApplicationPort port) throws Exception {
+  public SBPortProcessorResult process(Object value, String id, Object schema, Object binding, ApplicationPort parentPort) throws Exception {
     if (SBSchemaHelper.isFileFromValue(value)) {
       Object clonedValue = CloneHelper.deepCopy(value);
 

--- a/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/processor/callback/SBFileValueProcessorCallback.java
+++ b/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/processor/callback/SBFileValueProcessorCallback.java
@@ -8,9 +8,7 @@ import java.util.Set;
 
 import org.rabix.bindings.model.ApplicationPort;
 import org.rabix.bindings.model.FileValue;
-import org.rabix.bindings.sb.bean.SBInputPort;
 import org.rabix.bindings.sb.bean.SBJob;
-import org.rabix.bindings.sb.bean.SBOutputPort;
 import org.rabix.bindings.sb.expression.helper.SBExpressionBeanHelper;
 import org.rabix.bindings.sb.helper.SBBindingHelper;
 import org.rabix.bindings.sb.helper.SBFileValueHelper;
@@ -33,8 +31,8 @@ public class SBFileValueProcessorCallback implements SBPortProcessorCallback {
   }
   
   @Override
-  public SBPortProcessorResult process(Object value, ApplicationPort port) throws Exception {
-    if (SBSchemaHelper.isFileFromValue(value) && !skip(port.getId())) {
+  public SBPortProcessorResult process(Object value, String id, Object schema, Object binding, ApplicationPort parentPort) throws Exception {
+    if (SBSchemaHelper.isFileFromValue(value) && !skip(id)) {
       FileValue fileValue = SBFileValueHelper.createFileValue(value);
       
       List<Map<String, Object>> secondaryFiles = SBFileValueHelper.getSecondaryFiles(value);
@@ -47,12 +45,6 @@ public class SBFileValueProcessorCallback implements SBPortProcessorCallback {
       } else {
         // try to create secondary files
         if (generateSecondaryFilePaths) {
-          Object binding = null;
-          if (port instanceof SBInputPort) {
-            binding = ((SBInputPort) port).getInputBinding();
-          } else {
-            binding = ((SBOutputPort) port).getOutputBinding();
-          }
           List<String> secondaryFileSufixes = SBBindingHelper.getSecondaryFiles(binding);
           if (secondaryFileSufixes != null) {
 

--- a/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/processor/callback/SBFileValueUpdateProcessorCallback.java
+++ b/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/processor/callback/SBFileValueUpdateProcessorCallback.java
@@ -22,7 +22,7 @@ public class SBFileValueUpdateProcessorCallback implements SBPortProcessorCallba
   }
 
   @Override
-  public SBPortProcessorResult process(Object value, ApplicationPort port) throws Exception {
+  public SBPortProcessorResult process(Object value, String id, Object schema, Object binding, ApplicationPort parentPort) throws Exception {
     if (SBSchemaHelper.isFileFromValue(value)) {
       Object clonedValue = CloneHelper.deepCopy(value);
 

--- a/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/processor/callback/SBLoadContentsPortProcessorCallback.java
+++ b/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/processor/callback/SBLoadContentsPortProcessorCallback.java
@@ -12,16 +12,15 @@ import org.rabix.common.helper.CloneHelper;
 public class SBLoadContentsPortProcessorCallback implements SBPortProcessorCallback {
 
   @Override
-  public SBPortProcessorResult process(Object value, ApplicationPort port) throws Exception {
-    if (SBSchemaHelper.isFileFromValue(value) && port instanceof SBInputPort) {
+  public SBPortProcessorResult process(Object value, String id, Object schema, Object binding, ApplicationPort parentPort) throws Exception {
+    if (SBSchemaHelper.isFileFromValue(value) && parentPort instanceof SBInputPort) {
       Object clonedValue = CloneHelper.deepCopy(value);
       
-      Object inputBinding = ((SBInputPort) port).getInputBinding();
-      if (inputBinding == null) {
+      if (binding == null) {
         return new SBPortProcessorResult(clonedValue, true);
       }
-
-      boolean loadContents = SBBindingHelper.loadContents(inputBinding);
+      
+      boolean loadContents = SBBindingHelper.loadContents(binding);
       if (loadContents) {
         SBFileValueHelper.setContents(clonedValue);
         return new SBPortProcessorResult(clonedValue, true);

--- a/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/processor/callback/SBMetadataCallback.java
+++ b/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/processor/callback/SBMetadataCallback.java
@@ -66,7 +66,7 @@ public class SBMetadataCallback implements SBPortProcessorCallback {
   }
   
   @Override
-  public SBPortProcessorResult process(Object value, ApplicationPort port) throws Exception {
+  public SBPortProcessorResult process(Object value, String id, Object schema, Object binding, ApplicationPort parentPort) throws Exception {
     if (SBSchemaHelper.isFileFromValue(value)) {
       Object clonedValue = CloneHelper.deepCopy(value);
       String path = SBFileValueHelper.getPath(clonedValue);

--- a/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/processor/callback/SBStageInputProcessorCallback.java
+++ b/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/processor/callback/SBStageInputProcessorCallback.java
@@ -32,11 +32,11 @@ public class SBStageInputProcessorCallback implements SBPortProcessorCallback {
   }
 
   @Override
-  public SBPortProcessorResult process(Object value, ApplicationPort port) throws Exception {
-    if (!(port instanceof SBInputPort)) {
+  public SBPortProcessorResult process(Object value, String id, Object schema, Object binding, ApplicationPort parentPort) throws Exception {
+    if (!(parentPort instanceof SBInputPort)) {
       throw new RuntimeException("Inputs only can be staged!");
     }
-    SBInputPort inputPort = (SBInputPort) port;
+    SBInputPort inputPort = (SBInputPort) parentPort;
     StageInput stageInput = inputPort.getStageInput();
     if (stageInput == null) {
       return new SBPortProcessorResult(value, true);

--- a/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/processor/callback/SBStageInputProcessorCallback.java
+++ b/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/processor/callback/SBStageInputProcessorCallback.java
@@ -12,7 +12,7 @@ import java.util.Map.Entry;
 import org.apache.commons.io.FileUtils;
 import org.rabix.bindings.BindingException;
 import org.rabix.bindings.model.ApplicationPort;
-import org.rabix.bindings.model.ApplicationPort.StageInput;
+import org.rabix.bindings.model.StageInput;
 import org.rabix.bindings.sb.bean.SBInputPort;
 import org.rabix.bindings.sb.helper.SBFileValueHelper;
 import org.rabix.bindings.sb.helper.SBSchemaHelper;

--- a/rabix-bindings/src/main/java/org/rabix/bindings/model/Application.java
+++ b/rabix-bindings/src/main/java/org/rabix/bindings/model/Application.java
@@ -78,7 +78,7 @@ public abstract class Application {
       if (inputValue==null && input.isRequired() && input.getDefaultValue()==null) {
         ret.put(inputId, "Required field");
       } else {
-        String s = input.validateInput(inputValue);
+        String s = input.validate(inputValue);
         if (s!=null)
           ret.put(inputId, s);
       }

--- a/rabix-bindings/src/main/java/org/rabix/bindings/model/ApplicationPort.java
+++ b/rabix-bindings/src/main/java/org/rabix/bindings/model/ApplicationPort.java
@@ -13,8 +13,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
-import com.google.common.base.Preconditions;
 
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -129,14 +127,15 @@ public abstract class ApplicationPort {
   public boolean isRequired() {
     return false;
   }
-
+  
+  public abstract Object getBinding();
   /**
    * Checks if supplied value is valid for this ApplicationPort
    * @param in Potential input value
    * @return null if input is valid else description why input is not valid
    */
   @JsonIgnore
-  public String validateInput(Object in) {
+  public String validate(Object in) {
     if (in==null)
       return null;
 
@@ -145,29 +144,4 @@ public abstract class ApplicationPort {
       return "Invalid Value for " + id + ".\n Expected: " + getDataType() + ".\n Received: " + inDataType;
     return null;
   }
-  
-  public static enum StageInput {
-    COPY("copy"), LINK("link");
-    
-    private String value;
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-    private StageInput(String value) {
-      this.value = value;
-    }
-    
-    public static StageInput get(String value) {
-      Preconditions.checkNotNull(value);
-      for (StageInput stageInput : values()) {
-        if (value.compareToIgnoreCase(stageInput.value) == 0) {
-          return stageInput;
-        }
-      }
-      throw new IllegalArgumentException("Wrong stageInput value " + value);
-    }
-  }
-  
 }

--- a/rabix-bindings/src/main/java/org/rabix/bindings/model/StageInput.java
+++ b/rabix-bindings/src/main/java/org/rabix/bindings/model/StageInput.java
@@ -1,0 +1,28 @@
+package org.rabix.bindings.model;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.base.Preconditions;
+
+public enum StageInput {
+  COPY("copy"), LINK("link");
+  
+  private String value;
+
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+  private StageInput(String value) {
+    this.value = value;
+  }
+  
+  public static StageInput get(String value) {
+    Preconditions.checkNotNull(value);
+    for (StageInput stageInput : values()) {
+      if (value.compareToIgnoreCase(stageInput.value) == 0) {
+        return stageInput;
+      }
+    }
+    throw new IllegalArgumentException("Wrong stageInput value " + value);
+  }
+}

--- a/rabix-engine/src/test/java/org/rabix/engine/test/TestPort.java
+++ b/rabix-engine/src/test/java/org/rabix/engine/test/TestPort.java
@@ -40,4 +40,10 @@ public class TestPort extends ApplicationPort {
     return new DAGLinkPort(fullId, fullId, DAGLinkPort.LinkPortType.OUTPUT, lm, scatter, defaultValue, null);
   }
 
+  @Override
+  public Object getBinding() {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
 }


### PR DESCRIPTION
Made some changes to the PortProcessing system to allow processing files in record schema. (currently only for CWL and sbdraft)

Also allowed for the return of not-existing secondary files, this might need to be augmented with some validation method or configuration.