### PR TITLE
Creates a relative path for traversal of embedded workflows

### DIFF
--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/resolver/CWLDocumentResolver.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/resolver/CWLDocumentResolver.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -317,7 +318,7 @@ public class CWLDocumentResolver {
 
         JsonNode referenceDocumentRoot = findDocumentRoot(root, file, referencePath, isJsonPointer);
         ParentChild parentChild = findReferencedNode(referenceDocumentRoot, referencePath);
-        JsonNode resolvedNode = traverse(appUrl, root, file, parentChild.parent, parentChild.child, false);
+        JsonNode resolvedNode = traverse(appUrl, root, file.getParentFile().toPath().resolve(referencePath).toFile(), parentChild.parent, parentChild.child, false);
         if (resolvedNode == null) {
           return null;
         }


### PR DESCRIPTION
Instead of always using the root one.

Relates to https://github.com/rabix/bunny/issues/281

TODO: previous drafts