### PR TITLE
Conformance tests fixes

### DIFF
--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/CWLProcessor.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/CWLProcessor.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import org.apache.commons.io.FileUtils;
@@ -33,6 +34,7 @@ import org.rabix.bindings.cwl.processor.CWLPortProcessor;
 import org.rabix.bindings.cwl.processor.CWLPortProcessorException;
 import org.rabix.bindings.cwl.processor.callback.CWLFilePathMapProcessorCallback;
 import org.rabix.bindings.cwl.processor.callback.CWLPortProcessorHelper;
+import org.rabix.bindings.cwl.resolver.CWLDocumentResolver;
 import org.rabix.bindings.cwl.service.CWLGlobException;
 import org.rabix.bindings.cwl.service.CWLGlobService;
 import org.rabix.bindings.cwl.service.CWLMetadataService;
@@ -332,7 +334,13 @@ public class CWLProcessor implements ProtocolProcessor {
   
   @SuppressWarnings("unchecked")
   private Object setFormat(Object result, Object format, CWLJob job) throws CWLExpressionException {
-    Object resolved = CWLExpressionResolver.resolve(format, job, null);
+    String resolved = CWLExpressionResolver.resolve(format, job, null);
+    Object namespaces = job.getApp().getRaw().get(CWLDocumentResolver.NAMESPACES_KEY);
+    if (namespaces instanceof Map) {
+      for (Entry<String, String> entry : ((Map<String, String>) namespaces).entrySet()) {
+        resolved = resolved.replace(entry.getKey() + ":", entry.getValue());
+      }
+    }
     ((Map<String, Object>) result).put("format", resolved);
     return result;
   }

--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/expression/CWLExpressionResolver.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/expression/CWLExpressionResolver.java
@@ -91,6 +91,9 @@ public class CWLExpressionResolver {
       Matcher m = segPattern.matcher(remaining);
       if (m.find()) {
         if (m.group(0).startsWith(".")) {
+          if(m.group(0).equals(".length") && vars instanceof List){
+            return ((List) vars).size();
+          }
           return nextSegment(remaining.substring(m.end(0)), ((Map<?, ?>) vars).get(m.group(0).substring(1)));
         } else if (m.group(0).charAt(1) == '\"' || m.group(0).charAt(1) == '\'') {
           Character start = m.group(0).charAt(1);

--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/resolver/CWLDocumentResolver.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/resolver/CWLDocumentResolver.java
@@ -127,7 +127,7 @@ public class CWLDocumentResolver {
 
     if (root.has(NAMESPACES_KEY)) {
       populateNamespaces(root);
-      ((ObjectNode) root).remove(NAMESPACES_KEY);
+//      ((ObjectNode) root).remove(NAMESPACES_KEY);
     }
     
 

--- a/rabix-bindings/src/main/java/org/rabix/bindings/CommandLine.java
+++ b/rabix-bindings/src/main/java/org/rabix/bindings/CommandLine.java
@@ -33,10 +33,10 @@ public class CommandLine {
       builder.append(part.toString()).append(PART_SEPARATOR);
     }
     if (!StringUtils.isEmpty(standardIn)) {
-      builder.append(PART_SEPARATOR).append("<").append(PART_SEPARATOR).append(standardIn);
+      builder.append("<").append(PART_SEPARATOR).append(standardIn).append(PART_SEPARATOR);
     }
     if (!StringUtils.isEmpty(standardOut)) {
-      builder.append(PART_SEPARATOR).append(">").append(PART_SEPARATOR).append(standardOut);
+      builder.append(">").append(PART_SEPARATOR).append(standardOut);
     }
     return normalizeCommandLine(builder.toString());
   }
@@ -45,7 +45,7 @@ public class CommandLine {
    * Normalize command line (remove multiple spaces, etc.)
    */
   private String normalizeCommandLine(String commandLine) {
-    return commandLine.trim().replaceAll(PART_SEPARATOR + "+", PART_SEPARATOR);
+    return commandLine.trim();//.replaceAll(PART_SEPARATOR + "+", PART_SEPARATOR);
   }
   
   public List<String> getParts() {


### PR DESCRIPTION
Explicitly added .length to expressions and namespace resolution at output generation. Removed the removal of multiple spaces from commandlines.