### PR TITLE
Added support for dirname field in FileValue for older drafts.

### DIFF
--- a/rabix-bindings-draft2/src/main/java/org/rabix/bindings/draft2/helper/Draft2FileValueHelper.java
+++ b/rabix-bindings-draft2/src/main/java/org/rabix/bindings/draft2/helper/Draft2FileValueHelper.java
@@ -26,6 +26,7 @@ public class Draft2FileValueHelper extends Draft2BeanHelper {
   private static final String KEY_CONTENTS = "contents";
   private static final String KEY_ORIGINAL_PATH = "originalPath";
   private static final String KEY_SECONDARY_FILES = "secondaryFiles";
+  private static final String KEY_DIRNAME = "dirname";
 
   private static final int CONTENTS_NUMBER_OF_BYTES = 65536;
 
@@ -85,6 +86,14 @@ public class Draft2FileValueHelper extends Draft2BeanHelper {
   
   public static String getChecksum(Object raw) {
     return getValue(KEY_CHECKSUM, raw);
+  }
+
+  public static String getDirname(Object raw) {
+    return getValue(KEY_DIRNAME, raw);
+  }
+
+  public static void setDirname(String name, Object raw) {
+    setValue(KEY_DIRNAME, name, raw);
   }
 
   public static String getPath(Object raw) {
@@ -186,6 +195,7 @@ public class Draft2FileValueHelper extends Draft2BeanHelper {
     String contents = Draft2FileValueHelper.getContents(value);
     String location = Draft2FileValueHelper.getLocation(value);
     String checksum = Draft2FileValueHelper.getChecksum(value);
+    String dirname = Draft2FileValueHelper.getDirname(value);
     Long size = Draft2FileValueHelper.getSize(value);
     
     Map<String, Object> properties = new HashMap<>();
@@ -198,7 +208,9 @@ public class Draft2FileValueHelper extends Draft2BeanHelper {
         secondaryFiles.add(createFileValue(secondaryFileValue));
       }
     }
-    return new FileValue(size, path, location, checksum, secondaryFiles, properties, name, null, contents);
+    FileValue ret = new FileValue(size, path, location, checksum, secondaryFiles, properties, name, null, contents);
+    ret.setDirname(dirname);
+    return ret;
   }
   
   public static Map<String, Object> createFileRaw(FileValue fileValue) {
@@ -211,6 +223,7 @@ public class Draft2FileValueHelper extends Draft2BeanHelper {
     setChecksum(fileValue.getChecksum(), raw);
     setSize(fileValue.getSize(), raw);
     setContents(fileValue.getContents(), raw);
+    setDirname(fileValue.getDirname(), raw);
     
     Map<String, Object> properties = fileValue.getProperties();
     if (properties != null) {

--- a/rabix-bindings-draft3/src/main/java/org/rabix/bindings/draft3/helper/Draft3FileValueHelper.java
+++ b/rabix-bindings-draft3/src/main/java/org/rabix/bindings/draft3/helper/Draft3FileValueHelper.java
@@ -27,6 +27,7 @@ public class Draft3FileValueHelper extends Draft3BeanHelper {
   private static final String KEY_CONTENTS = "contents";
   private static final String KEY_ORIGINAL_PATH = "originalPath";
   private static final String KEY_SECONDARY_FILES = "secondaryFiles";
+  private static final String KEY_DIRNAME = "dirname";
 
   private static final int CONTENTS_NUMBER_OF_BYTES = 65536;
 
@@ -74,7 +75,16 @@ public class Draft3FileValueHelper extends Draft3BeanHelper {
       setValue(KEY_CHECKSUM, checksum, raw);
     }
   }
-  
+
+  public static String getDirname(Object raw) {
+    return getValue(KEY_DIRNAME, raw);
+  }
+
+  public static void setDirname(String name, Object raw) {
+    setValue(KEY_DIRNAME, name, raw);
+  }
+
+
   public static void setChecksum(String checksum, Object raw) {
     setValue(KEY_CHECKSUM, checksum, raw);
   }
@@ -196,6 +206,7 @@ public class Draft3FileValueHelper extends Draft3BeanHelper {
     String format = Draft3FileValueHelper.getFormat(value);
     String checksum = Draft3FileValueHelper.getChecksum(value);
     String contents = Draft3FileValueHelper.getContents(value);
+    String dirname = Draft3FileValueHelper.getDirname(value);
     Long size = Draft3FileValueHelper.getSize(value);
     
     Map<String, Object> properties = new HashMap<>();
@@ -208,7 +219,9 @@ public class Draft3FileValueHelper extends Draft3BeanHelper {
         secondaryFiles.add(createFileValue(secondaryFileValue));
       }
     }
-    return new FileValue(size, path, location, checksum, secondaryFiles, properties, name, format, contents);
+    FileValue ret = new FileValue(size, path, location, checksum, secondaryFiles, properties, name, format, contents);
+    ret.setDirname(dirname);
+    return ret;
   }
   
   public static Map<String, Object> createFileRaw(FileValue fileValue) {
@@ -222,6 +235,7 @@ public class Draft3FileValueHelper extends Draft3BeanHelper {
     setChecksum(fileValue.getChecksum(), raw);
     setSize(fileValue.getSize(), raw);
     setContents(fileValue.getContents(), raw);
+    setDirname(fileValue.getDirname(), raw);
     
     Map<String, Object> properties = fileValue.getProperties();
     if (properties != null) {

--- a/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/helper/SBFileValueHelper.java
+++ b/rabix-bindings-sb/src/main/java/org/rabix/bindings/sb/helper/SBFileValueHelper.java
@@ -26,6 +26,7 @@ public class SBFileValueHelper extends SBBeanHelper {
   private static final String KEY_CONTENTS = "contents";
   private static final String KEY_ORIGINAL_PATH = "originalPath";
   private static final String KEY_SECONDARY_FILES = "secondaryFiles";
+  private static final String KEY_DIRNAME = "dirname";
 
   private static final int CONTENTS_NUMBER_OF_BYTES = 65536;
 
@@ -68,6 +69,14 @@ public class SBFileValueHelper extends SBBeanHelper {
   
   public static void setChecksum(String checksum, Object raw) {
     setValue(KEY_CHECKSUM, checksum, raw);
+  }
+
+  public static String getDirname(Object raw) {
+    return getValue(KEY_DIRNAME, raw);
+  }
+
+  public static void setDirname(String name, Object raw) {
+    setValue(KEY_DIRNAME, name, raw);
   }
 
   public static void setContents(Object raw) throws IOException {
@@ -186,6 +195,7 @@ public class SBFileValueHelper extends SBBeanHelper {
     String location = SBFileValueHelper.getLocation(value);
     String checksum = SBFileValueHelper.getChecksum(value);
     String contents = SBFileValueHelper.getContents(value);
+    String dirname = SBFileValueHelper.getDirname(value);
     Long size = SBFileValueHelper.getSize(value);
     
     Map<String, Object> properties = new HashMap<>();
@@ -198,7 +208,10 @@ public class SBFileValueHelper extends SBBeanHelper {
         secondaryFiles.add(createFileValue(secondaryFileValue));
       }
     }
-    return new FileValue(size, path, location, checksum, secondaryFiles, properties, name, null, contents);
+
+    FileValue ret = new FileValue(size, path, location, checksum, secondaryFiles, properties, name, null, contents);
+    ret.setDirname(dirname);
+    return ret;
   }
   
   public static Map<String, Object> createFileRaw(FileValue fileValue) {
@@ -211,6 +224,7 @@ public class SBFileValueHelper extends SBBeanHelper {
     setChecksum(fileValue.getChecksum(), raw);
     setSize(fileValue.getSize(), raw);
     setContents(fileValue.getContents(), raw);
+    setDirname(fileValue.getDirname(), raw);
 
     Map<String, Object> properties = fileValue.getProperties();
     if (properties != null) {


### PR DESCRIPTION
Sometimes, we need to use dirname value in older drafts. This should populate dirname inside FileValue for Draft2, SB and Draft3, same as it's being done for CWL. 