### PR TITLE
Deserializing maps with null values

### DIFF
--- a/rabix-common/src/main/java/org/rabix/common/helper/JSONHelper.java
+++ b/rabix-common/src/main/java/org/rabix/common/helper/JSONHelper.java
@@ -256,9 +256,7 @@ public class JSONHelper {
       while (iterator.hasNext()) {
         Map.Entry<String, JsonNode> subnodeEntry = iterator.next();
         Object result = transform(subnodeEntry.getValue(), skipNull);
-        if (skipNull && result == null) {
-          return resultMap;
-        } else {
+        if (!skipNull || result != null) {
           resultMap.put(subnodeEntry.getKey(), result);         
         }
       }


### PR DESCRIPTION
Everything in a deserialized map shouldn’t be skipped if it comes after a null value

Relates to https://github.com/rabix/bunny/issues/322