### PR TITLE
Fix for skipping steps

### DIFF
--- a/rabix-engine/src/main/java/org/rabix/engine/processor/handler/impl/InitEventHandler.java
+++ b/rabix-engine/src/main/java/org/rabix/engine/processor/handler/impl/InitEventHandler.java
@@ -7,6 +7,7 @@ import org.rabix.bindings.model.dag.DAGContainer;
 import org.rabix.bindings.model.dag.DAGLinkPort;
 import org.rabix.bindings.model.dag.DAGLinkPort.LinkPortType;
 import org.rabix.bindings.model.dag.DAGNode;
+import org.rabix.bindings.model.dag.DAGNode.DAGNodeType;
 import org.rabix.common.helper.CloneHelper;
 import org.rabix.common.helper.InternalSchemaHelper;
 import org.rabix.engine.event.impl.InitEvent;
@@ -80,7 +81,8 @@ public class InitEventHandler implements EventHandler<InitEvent> {
     }
 
     for (DAGLinkPort outputPort : node.getOutputPorts()) {
-      jobRecordService.incrementPortCounter(job, outputPort, LinkPortType.OUTPUT);
+      if(!node.getType().equals(DAGNodeType.CONTAINER))
+        jobRecordService.incrementPortCounter(job, outputPort, LinkPortType.OUTPUT);
 
       VariableRecord variable = new VariableRecord(event.getContextId(), node.getId(), outputPort.getId(), LinkPortType.OUTPUT, null, node.getLinkMerge(outputPort.getId(), outputPort.getType()));
       variableRecordService.create(variable);

--- a/rabix-engine/src/main/java/org/rabix/engine/processor/handler/impl/JobStatusEventHandler.java
+++ b/rabix-engine/src/main/java/org/rabix/engine/processor/handler/impl/JobStatusEventHandler.java
@@ -438,11 +438,11 @@ public class JobStatusEventHandler implements EventHandler<JobStatusEvent> {
         }
       }
     } else {
+      jobRecordService.increaseOutputPortIncoming(job, linkPort.getId());
       jobRecordService.incrementPortCounter(job, linkPort, LinkPortType.OUTPUT);
       if (isSource) {
         job.getOutputCounter(linkPort.getId()).updatedAsSource(1);
       }
-      jobRecordService.increaseOutputPortIncoming(job, linkPort.getId());
     }
     jobRecordService.update(job);
   }

--- a/rabix-engine/src/main/java/org/rabix/engine/service/impl/JobRecordServiceImpl.java
+++ b/rabix-engine/src/main/java/org/rabix/engine/service/impl/JobRecordServiceImpl.java
@@ -132,7 +132,7 @@ public class JobRecordServiceImpl implements JobRecordService {
             if (type.equals(LinkPortType.OUTPUT)) {
               if (jobRecord.isScatterWrapper()) {
                 pc.counter = pc.counter + 1;
-              } else if (jobRecord.isContainer() && pc.incoming > 1) {
+              } else if (jobRecord.isContainer()) {
                 pc.counter = pc.counter + 1;
               }
             }


### PR DESCRIPTION
Fix for skipping steps when there are multiple incoming values for one of the root apps' output port