### PR TITLE
Multistage Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+*.tmp
+*.iml
+*.bak
+*.swp
+*~.nib
+.*
+*.tar.gz
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM maven:3.5-jdk-8 as builder
+
+COPY . /opt/bunny
+WORKDIR /opt/bunny
+RUN mvn install -P all
+RUN tar xzf rabix-cli/target/rabix-cli-*-release.tar.gz
+
+FROM openjdk:8-jre-slim
+
+COPY --from=builder /opt/bunny/rabix-cli-* /opt/rabix-cli
+RUN ln -s /opt/rabix-cli/rabix /usr/bin/rabix


### PR DESCRIPTION
Minimal Dockerfile for rabix-cli.

Uses the multistage build process available from Docker 17.05 to keep the image size small.

https://docs.docker.com/engine/userguide/eng-image/multistage-build/