### PR TITLE
Docker start container smarter retry

### DIFF
--- a/rabix-executor/src/main/java/org/rabix/executor/container/impl/DockerContainerHandler.java
+++ b/rabix-executor/src/main/java/org/rabix/executor/container/impl/DockerContainerHandler.java
@@ -58,6 +58,7 @@ import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.DockerClient.LogsParam;
 import com.spotify.docker.client.LogMessage;
 import com.spotify.docker.client.LogStream;
+import com.spotify.docker.client.exceptions.ContainerNotFoundException;
 import com.spotify.docker.client.exceptions.DockerCertificateException;
 import com.spotify.docker.client.exceptions.DockerException;
 import com.spotify.docker.client.messages.AuthConfig;
@@ -256,18 +257,16 @@ public class DockerContainerHandler implements ContainerHandler {
       }
       
       builder.env(transformEnvironmentVariables(environmentVariables));
-      ContainerCreation creation = null;
       try {
         VerboseLogger.log(String.format("Running command line: %s", commandLine));
-        creation = dockerClient.createContainer(builder.build());
+        containerId = dockerClient.createContainer(builder.build());
       } catch (DockerException | InterruptedException e) {
         logger.error("Failed to create Docker container.", e);
         throw new ContainerException("Failed to create Docker container.");
       }
-      containerId = creation.id();
       try {
         dockerClient.startContainer(containerId);
-      } catch (DockerException | InterruptedException e) {
+      } catch (Exception e) {
         logger.error("Failed to start Docker container " + containerId, e);
         throw new ContainerException("Failed to start Docker container " + containerId);
       }
@@ -556,13 +555,21 @@ public class DockerContainerHandler implements ContainerHandler {
     }
     
     @Retry(times = RETRY_TIMES, methodTimeoutMillis = METHOD_TIMEOUT, exponentialBackoff = true)
-    public synchronized ContainerCreation createContainer(ContainerConfig containerConfig) throws DockerException, InterruptedException {
-      return dockerClient.createContainer(containerConfig);
+    public synchronized String createContainer(ContainerConfig containerConfig) throws DockerException, InterruptedException {
+      return dockerClient.createContainer(containerConfig).id();
     }
     
     @Retry(times = RETRY_TIMES, methodTimeoutMillis = METHOD_TIMEOUT, exponentialBackoff = true)
     public synchronized void startContainer(String containerId) throws DockerException, InterruptedException {
-      dockerClient.startContainer(containerId);
+      try {
+        dockerClient.startContainer(containerId);
+      } catch (DockerException e) {
+        ContainerInfo inspect = dockerClient.inspectContainer(containerId);
+        if (inspect == null || inspect.state().startedAt() == null) {
+          throw e;
+        }
+        logger.warn("Start container method timed-out but still started the container, recovering.");
+      }
     }
     
     @Retry(times = RETRY_TIMES, methodTimeoutMillis = METHOD_TIMEOUT, exponentialBackoff = true)

--- a/rabix-executor/src/main/java/org/rabix/executor/service/impl/FilePermissionServiceImpl.java
+++ b/rabix-executor/src/main/java/org/rabix/executor/service/impl/FilePermissionServiceImpl.java
@@ -63,8 +63,7 @@ public class FilePermissionServiceImpl implements FilePermissionService {
       String commandLine = getChmodCommand(workingDir) + ";" + getChownCommand(workingDir);
       builder.workingDir(workingDir.getAbsolutePath()).volumes(volumes).cmd("sh", "-c", commandLine);
 
-      ContainerCreation creation = dockerClient.createContainer(builder.build());
-      String containerId = creation.id();
+      String containerId = dockerClient.createContainer(builder.build());
       dockerClient.startContainer(containerId);
       logger.info("Docker container {} has started.", containerId);
       dockerClient.waitContainer(containerId);


### PR DESCRIPTION
Change for https://github.com/rabix/bunny/issues/371 where start container both started the container and failed due to time out, making the method retry. Now every retry of the start command checks if it actually completed before retrying.