### PR TITLE
Bugfix/job repo leak

### DIFF
--- a/rabix-engine/src/main/java/org/rabix/engine/processor/handler/impl/JobStatusEventHandler.java
+++ b/rabix-engine/src/main/java/org/rabix/engine/processor/handler/impl/JobStatusEventHandler.java
@@ -157,10 +157,7 @@ public class JobStatusEventHandler implements EventHandler<JobStatusEvent> {
         jobService.delete(jobRecord.getRootId(), jobRecord.getExternalId());
       }
 
-      if (jobStatsRecord != null) {
-        jobStatsRecord.increaseCompleted();
-        jobStatsRecordService.update(jobStatsRecord);
-      }
+      updateJobStats(jobRecord, jobStatsRecord);
 
       if ((!jobRecord.isScatterWrapper() || jobRecord.isRoot()) && !jobRecord.isContainer()) {
         for (PortCounter portCounter : jobRecord.getOutputCounters()) {
@@ -234,6 +231,13 @@ public class JobStatusEventHandler implements EventHandler<JobStatusEvent> {
       break;
     default:
       break;
+    }
+  }
+
+  private void updateJobStats(JobRecord jobRecord, JobStatsRecord jobStatsRecord) {
+    if (jobStatsRecord != null && !(jobRecord.isRoot() && jobRecord.isContainer())) {
+      jobStatsRecord.increaseCompleted();
+      jobStatsRecordService.update(jobStatsRecord);
     }
   }
 
@@ -430,7 +434,7 @@ public class JobStatusEventHandler implements EventHandler<JobStatusEvent> {
       handleLinkPort(jobRecordService.find(destinationNodeId, contextId), link.getDestination(), false);
     }
     for (DAGNode node : containerNode.getChildren()) {
-      String newJobId = InternalSchemaHelper.concatenateIds(job.getId(), InternalSchemaHelper.getLastPart(node.getId()));   
+      String newJobId = InternalSchemaHelper.concatenateIds(job.getId(), InternalSchemaHelper.getLastPart(node.getId()));
       JobRecord childJob = jobRecordService.find(newJobId, contextId);
       if(childJob.isReady() && !childJob.isContainer()){
         JobStatusEvent jobStatusEvent = new JobStatusEvent(childJob.getId(), job.getRootId(), JobRecord.JobState.READY, job.getRootId(), null);

--- a/rabix-engine/src/main/java/org/rabix/engine/service/impl/GarbageCollectionServiceImpl.java
+++ b/rabix-engine/src/main/java/org/rabix/engine/service/impl/GarbageCollectionServiceImpl.java
@@ -1,5 +1,6 @@
 package org.rabix.engine.service.impl;
 
+import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import org.apache.commons.configuration.Configuration;
 import org.rabix.engine.metrics.MetricsHelper;
@@ -178,6 +179,7 @@ public class GarbageCollectionServiceImpl implements GarbageCollectionService {
     linkRecordRepository.deleteByRootId(rootId);
     contextRecordRepository.delete(rootId);
     intermediaryFilesRepository.delete(rootId);
+    jobRepository.deleteByRootIds(Sets.newHashSet(rootId));
 
     List<JobRecord> all = jobRecordRepository.get(rootId);
     flush(rootId, all);

--- a/rabix-engine/src/main/java/org/rabix/engine/service/impl/GarbageCollectionServiceImpl.java
+++ b/rabix-engine/src/main/java/org/rabix/engine/service/impl/GarbageCollectionServiceImpl.java
@@ -194,7 +194,7 @@ public class GarbageCollectionServiceImpl implements GarbageCollectionService {
             .collect(Collectors.toList());
 
     return outputJobRecords.isEmpty() || outputJobRecords.stream().allMatch(outputJobRecord -> {
-      if (!inTerminalState(outputJobRecord)) {
+      if (!outputJobRecord.isReady() || !inTerminalState(outputJobRecord)) {
         return false;
       }
       return !outputJobRecord.isContainer() || isGarbage(outputJobRecord);

--- a/rabix-engine/src/main/resources/org/rabix/engine/jdbi/dbinit.sql
+++ b/rabix-engine/src/main/resources/org/rabix/engine/jdbi/dbinit.sql
@@ -461,8 +461,8 @@ ALTER TABLE event ADD COLUMN root_id uuid;
 --rollback ALTER TABLE event drop column root_id;
 
 --changeset bunny:1487849040814-76 dbms:postgresql
-DROP INDEX event_status_index;
-DROP INDEX event_id_type_index;
-DROP INDEX backend_id_index;
-DROP INDEX context_record_id_index;
-DROP INDEX context_record_status_index;
+DROP INDEX IF EXISTS event_status_index;
+DROP INDEX IF EXISTS event_id_type_index;
+DROP INDEX IF EXISTS backend_id_index;
+DROP INDEX IF EXISTS context_record_id_index;
+DROP INDEX IF EXISTS context_record_status_index;


### PR DESCRIPTION
Upon root collection flush everything from job repository for given root id, thus preventing the leak. Also, number of completed jobs in job stats should not be incremented on completed event for root which is container. Finally, added additional check when checking if job is garbage (it should be ready, not only completed).