### PR TITLE
Fix CommandLineBuilder behaviour when prefix is null and itemSeparator is set.

### DIFF
--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/CWLCommandLineBuilder.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/CWLCommandLineBuilder.java
@@ -321,7 +321,12 @@ public class CWLCommandLineBuilder implements ProtocolCommandLineBuilder {
       if (itemSeparator != null) {
         String joinedItems = Joiner.on(itemSeparator).join(flattenedValues);
         if (prefix == null) {
-          return new CWLCommandLinePart.Builder(position, isFile).keyValue(keyValue).part(joinedItems).build();
+            List<Object> prefixedValues = new ArrayList<>();
+            for (Object arrayItem : flattenedValues) {
+              prefixedValues.add(itemSeparator);
+              prefixedValues.add(arrayItem);
+            }
+            return new CWLCommandLinePart.Builder(position, isFile).keyValue(keyValue).parts(prefixedValues).build();
         }
         if (StringUtils.isWhitespace(separator) && separator.length() > 0) {
           return new CWLCommandLinePart.Builder(position, isFile).keyValue(keyValue).part(prefix).part(joinedItems).build();

--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/CWLCommandLineBuilder.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/CWLCommandLineBuilder.java
@@ -333,8 +333,8 @@ public class CWLCommandLineBuilder implements ProtocolCommandLineBuilder {
         return new CWLCommandLinePart.Builder(position, isFile).keyValue(keyValue).parts(flattenedValues).build();
       }
       List<Object> prefixedValues = new ArrayList<>();
-      prefixedValues.add(prefix);
       for (Object arrayItem : flattenedValues) {
+        prefixedValues.add(prefix);
         prefixedValues.add(arrayItem);
       }
       return new CWLCommandLinePart.Builder(position, isFile).keyValue(keyValue).parts(prefixedValues).build();


### PR DESCRIPTION
I'm working with Rabix Composer to create a workflow that has an array as input. The result is something like this:

```
cwlVersion: v1.0
class: CommandLineTool

baseCommand: 
  - command

inputs:
  - id: inputs_separated
    type: 'File[]'
    inputBinding:
      prefix: '-I'
      itemSeparator: null

outputs:
   output:
    type: stdout
```

It should produce the command `command -I input1 -I input2`, but it produces `command -I input1 input2`

I tried to change itemSeparator value to `' -I '`, but then, it produces `command -I 'input1 -I input2'`

This change should fix the issue.

