### PR TITLE
Fix CommandLineBuilder behaviour when prefix is null and itemSeparator is set

### DIFF
--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/CWLCommandLineBuilder.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/CWLCommandLineBuilder.java
@@ -328,7 +328,12 @@ public class CWLCommandLineBuilder implements ProtocolCommandLineBuilder {
       if (itemSeparator != null) {
         String joinedItems = Joiner.on(itemSeparator).join(flattenedValues);
         if (prefix == null) {
-          return new CWLCommandLinePart.Builder(position, isFile).keyValue(keyValue).part(joinedItems).build();
+          List<Object> prefixedValues = new ArrayList<>();
+          for (Object arrayItem : flattenedValues) {
+            prefixedValues.add(itemSeparator);
+            prefixedValues.add(arrayItem);
+          }
+          return new CWLCommandLinePart.Builder(position, isFile).keyValue(keyValue).parts(prefixedValues).build();
         }
         if (StringUtils.isWhitespace(separator) && separator.length() > 0) {
           return new CWLCommandLinePart.Builder(position, isFile).keyValue(keyValue).part(prefix).part(joinedItems).build();


### PR DESCRIPTION
I closed #430 and opened this new PR, to apply the latest changes from master.

I realized that the problem just happened when prefix was null and itemSeparator was set.

For example, when itemSeparator was set to `'-I'`, it produced: `command input1-Iinput2`

And when it was set to `' -I '`, it produced: `command 'input1 -I input2'`

I made some changes to fix this problem.

Now, when I set itemSeparator to `'-I'` it produces de correct command: `command -I input1 -I input2`