### PR TITLE
change example config for amazon s3; fix variable scope issue

### DIFF
--- a/rabix-cli/config/core.properties
+++ b/rabix-cli/config/core.properties
@@ -53,7 +53,8 @@ tes.postprocessing_thread_pool=1
 #if gs is used, authentication is taken from the environment
 #for s3 the following keys should be added to a config file: s3.access_key, s3.secret_key
 
-tes.storage_base=s3://endpoint/bucket/folder
+tes.storage_base=s3://s3.amazonaws.com/<your-bucket>
+#tes.storage_base=file:///your/local/path
 
 #S3 options.
 #Format: s3.<provider_name>.<option>
@@ -68,7 +69,7 @@ s3.amazon.max_retry_error=10
 s3.amazon.connection_timeout=50000
 s3.amazon.max_connections=50
 s3.amazon.socket_timeout=50000
-s3.amazon.signer_override=AWS4SignerType
+s3.amazon.signer_override=AWSS3V4SignerType
 s3.amazon.path_style_access=false
 
 s3.ceph.endpoints= s3://cephhost:8888/

--- a/rabix-cli/src/main/java/org/rabix/cli/BackendCommandLine.java
+++ b/rabix-cli/src/main/java/org/rabix/cli/BackendCommandLine.java
@@ -404,13 +404,13 @@ public class BackendCommandLine {
         commonInputs = bindings.translateToCommon(inputs);
         if (inputsFile != null) {
           final Path finalInputs = inputsFile;
-          FileValueHelper.updateFileValues(commonInputs, (FileValue f) -> {
-            fixPaths(finalInputs, f);
-            if (f.getSecondaryFiles() != null)
-              for (FileValue sec : f.getSecondaryFiles()) {
+          FileValueHelper.updateFileValues(commonInputs, (FileValue file) -> {
+            fixPaths(finalInputs, file);
+            if (file.getSecondaryFiles() != null)
+              for (FileValue sec : file.getSecondaryFiles()) {
                 fixPaths(finalInputs, sec);
               }
-            return f;
+            return file;
           });
         }
       } catch (BindingException e1) {


### PR DESCRIPTION
closes #447 

Example `s3.amazon` config had the wrong default set for the signing method. 