### PR TITLE
add a check for the "name:" field for SchemaDefs

### DIFF
--- a/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/resolver/CWLDocumentResolver.java
+++ b/rabix-bindings-cwl/src/main/java/org/rabix/bindings/cwl/resolver/CWLDocumentResolver.java
@@ -541,12 +541,17 @@ public class CWLDocumentResolver {
 
     JsonNode parent = null;
     JsonNode child = rootNode;
+    JsonNode temp = null;
     for (String part : parts) {
       if (StringUtils.isEmpty(part)) {
         continue;
       }
       parent = child;
-      child = child.get(part);
+      temp = child.get(part);
+      if (temp == null) {
+        temp = child.get("name");
+      }
+      child = temp;
     }
     return new ParentChild(parent, child);
   }


### PR DESCRIPTION
As per the CWL spec, SchemaDefs should probably be able to be present using the `name:` field for OutputRecordSchema

https://www.commonwl.org/v1.1/Workflow.html#OutputRecordSchema

But rabix will only be satisfied if the #fragment is not present (`../resources/schemas/bam_sample.yaml`), 

cwltool on the other hand will only be valid with the fragment present it seems (`../resources/schemas/bam_sample.yaml#bam_sample`)



The mskcc / beagle team needs this for operator chaining, so hopefully it will provide the correct schema to the DB